### PR TITLE
Feat: [#14] Id, 닉네임 중복 체크 이슈를 해결하기 위한 Redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/melodymarket/application/service/UserJoinService.java
+++ b/src/main/java/com/melodymarket/application/service/UserJoinService.java
@@ -3,9 +3,9 @@ package com.melodymarket.application.service;
 import com.melodymarket.application.dto.UserDto;
 
 public interface UserJoinService {
-    void checkUserIdDuplication(String loginId);
+    void checkUserIdDuplication(String loginId, String sessionId);
 
-    void checkNicknameDuplication(String nickname);
+    void checkNicknameDuplication(String nickname, String sessionId);
 
-    void signUpUser(UserDto userDto);
+    void signUpUser(UserDto userDto, String sessionId);
 }

--- a/src/main/java/com/melodymarket/application/service/UserJoinServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/service/UserJoinServiceImpl.java
@@ -3,6 +3,7 @@ package com.melodymarket.application.service;
 import com.melodymarket.application.dto.UserDto;
 import com.melodymarket.domain.user.entity.UserEntity;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
+import com.melodymarket.infrastructure.redis.RedisService;
 import com.melodymarket.infrastructure.repository.UserRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -19,38 +22,48 @@ public class UserJoinServiceImpl implements UserJoinService {
     UserRepository userRepository;
     CryptPasswordService cryptPasswordService;
 
+    RedisService redisService;
+
     @Override
-    public void checkUserIdDuplication(String loginId) {
+    public void checkUserIdDuplication(String loginId, String sessionId) {
         log.debug("유저 중복 체크");
-        if (userRepository.existsByLoginId(loginId)) {
+        String keyType = "id:";
+
+        if (isIdentifierInCheckProgress(keyType + loginId, sessionId) || userRepository.existsByLoginId(loginId)) {
             throw new DataDuplicateKeyException("이미 존재하는 아이디 입니다.");
         }
+        redisService.setValue(keyType + loginId, sessionId, 3, TimeUnit.MINUTES);
     }
 
     @Override
-    public void checkNicknameDuplication(String nickname) {
+    public void checkNicknameDuplication(String nickname, String sessionId) {
         log.info("닉네임 중복체크");
-        if (userRepository.existsByNickname(nickname)) {
+        String keyType = "nickname:";
+
+        if (isIdentifierInCheckProgress(keyType + nickname, sessionId) || userRepository.existsByNickname(nickname)) {
             throw new DataDuplicateKeyException("이미 존재하는 닉네임 입니다.");
         }
+        redisService.setValue(nickname, "nickname", 3, TimeUnit.MINUTES);
     }
 
     @Override
-    public void signUpUser(UserDto userDto) {
+    public void signUpUser(UserDto userDto, String sessionId) {
         UserEntity userEntity = UserEntity.from(userDto, cryptPasswordService.encryptPassword(userDto.getUserPassword()));
 
-        if (userRepository.existsByNickname(userEntity.getNickname())) {
-            throw new DataDuplicateKeyException("이미 존재하는 닉네임 입니다.");
-        }else if (userRepository.existsByLoginId(userEntity.getLoginId())) {
-            throw new DataDuplicateKeyException("이미 존재하는 아이디 입니다.");
-        }
-
+        checkUserIdDuplication(userDto.getLoginId(),sessionId);
+        checkNicknameDuplication(userDto.getNickname(), sessionId);
         try {
             userRepository.save(userEntity);
         } catch (DataIntegrityViolationException e) {
             log.error("중복 데이터 회원가입 시도 ={}", userDto);
             throw new DataDuplicateKeyException("이미 가입 된 회원 정보 입니다.");
         }
+    }
+
+    public boolean isIdentifierInCheckProgress(String key, String sessionId) {
+        return redisService.getValue(key)
+                .map(value -> !value.equals(sessionId))
+                .orElse(false);
     }
 
 }

--- a/src/main/java/com/melodymarket/configuration/RedisConfig.java
+++ b/src/main/java/com/melodymarket/configuration/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.melodymarket.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+
+}

--- a/src/main/java/com/melodymarket/configuration/SecurityConfig.java
+++ b/src/main/java/com/melodymarket/configuration/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.melodymarket.configuration;
 
+import com.melodymarket.infrastructure.security.filter.JoinSessionCreationFilter;
 import com.melodymarket.infrastructure.security.handler.CustomAuthenticationSuccessHandler;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +13,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -24,6 +26,7 @@ public class SecurityConfig {
 
     /**
      * 보안 필터에 대한 예외처리
+     *
      * @return 정적 리소스에 대한 요청은 보안 요청을 무시하도록
      */
     @Bean
@@ -40,7 +43,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)//TODO: 우선은 생략 후 이후 csrf 적용할 것
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/","/login","/v1/user/join/*").permitAll()
+                        .requestMatchers("/", "/login", "/v1/user/join/*").permitAll()
                         .anyRequest().authenticated()
                 ).formLogin(formLogin -> formLogin
                         .successHandler(customAuthenticationSuccessHandler())
@@ -49,7 +52,7 @@ public class SecurityConfig {
                         .logoutSuccessUrl("/")
                         .invalidateHttpSession(true)
                         .permitAll());
-
+        http.addFilterBefore(new JoinSessionCreationFilter(), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/melodymarket/infrastructure/redis/RedisService.java
+++ b/src/main/java/com/melodymarket/infrastructure/redis/RedisService.java
@@ -1,0 +1,26 @@
+package com.melodymarket.infrastructure.redis;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RedisService {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    public RedisService(StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    public void setValue(String key, String value, long timeout, TimeUnit unit) {
+        stringRedisTemplate.opsForValue().set(key, value, timeout, unit);
+    }
+
+    public Optional<String> getValue(String key) {
+        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(key));
+    }
+}

--- a/src/main/java/com/melodymarket/infrastructure/security/filter/JoinSessionCreationFilter.java
+++ b/src/main/java/com/melodymarket/infrastructure/security/filter/JoinSessionCreationFilter.java
@@ -1,0 +1,19 @@
+package com.melodymarket.infrastructure.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JoinSessionCreationFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getRequestURI().matches("^/v1/user/join.*$")) {
+            request.getSession(true);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/melodymarket/presentation/admin/controller/JoinUserController.java
+++ b/src/main/java/com/melodymarket/presentation/admin/controller/JoinUserController.java
@@ -3,6 +3,7 @@ package com.melodymarket.presentation.admin.controller;
 import com.melodymarket.application.dto.UserDto;
 import com.melodymarket.application.service.UserJoinService;
 import com.melodymarket.application.service.UserJoinServiceImpl;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
@@ -32,9 +33,10 @@ public class JoinUserController {
      * @return User exists or User not exists
      */
     @GetMapping("/check-login-id")
-    public ResponseEntity<String> isUserIdAvailable(@RequestParam("login-id") String loginId) {
-        log.debug("[isUserIdAvailable] loginId={}", loginId);
-        userJoinService.checkUserIdDuplication(loginId);
+    public ResponseEntity<String> isUserIdAvailable(@RequestParam("login-id") String loginId,
+                                                    HttpServletRequest request) {
+        log.debug("[isUserIdAvailable] [Session_id={}] loginId={}", request.getSession(false).getId(), loginId);
+        userJoinService.checkUserIdDuplication(loginId, request.getSession(false).getId());
         return ResponseEntity.ok("사용 가능한 아이디 입니다.");
     }
 
@@ -45,9 +47,10 @@ public class JoinUserController {
      * @return User exists or User not exists
      */
     @GetMapping("/check-nickname")
-    public ResponseEntity<String> isNicknameAvailable(@RequestParam("nickname") String nickname) {
-        log.debug("[isNicknameAvailable] nickname={}", nickname);
-        userJoinService.checkNicknameDuplication(nickname);
+    public ResponseEntity<String> isNicknameAvailable(@RequestParam("nickname") String nickname,
+                                                      HttpServletRequest request) {
+        log.debug("[isNicknameAvailable] [Session_id={}] nickname={}", request.getSession(false).getId(), nickname);
+        userJoinService.checkNicknameDuplication(nickname, request.getSession(false).getId());
         return ResponseEntity.ok("사용 가능한 닉네임 입니다.");
     }
 
@@ -58,9 +61,10 @@ public class JoinUserController {
      * @return User exists or User not exists
      */
     @PostMapping("/save")
-    public ResponseEntity<Object> createUser(@RequestBody @Validated UserDto userDto) {
-        log.debug("[CreateUser] user info={}", userDto.toString());
-        userJoinService.signUpUser(userDto);
+    public ResponseEntity<Object> createUser(@RequestBody @Validated UserDto userDto,
+                                             HttpServletRequest request) {
+        log.debug("[CreateUser] [Session_id={}] user info={}", request.getSession(false).getId(),userDto.toString());
+        userJoinService.signUpUser(userDto, request.getSession(false).getId());
         return ResponseEntity.ok("유저 생성에 성공했습니다.");
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,10 @@ spring:
     hibernate:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 mybatis:
   mapper-locations: mybatis/mappers/UserMapper.xml

--- a/src/test/java/com/melodymarket/application/service/UserInfoManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/service/UserInfoManageServiceImplTest.java
@@ -32,11 +32,12 @@ class UserInfoManageServiceImplTest {
     UserRepository userRepository;
     UserDto userDto;
     UserEntity userSelect;
+    String sessionId="testSessionId";
 
     @BeforeEach
     void insert() {
         this.userDto = createTestUser();
-        userJoinServiceImpl.signUpUser(userDto);
+        userJoinServiceImpl.signUpUser(userDto,sessionId);
         this.userSelect = userRepository.findByLoginId("testuser").orElse(null);
     }
 

--- a/src/test/java/com/melodymarket/application/service/UserJoinServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/service/UserJoinServiceImplTest.java
@@ -20,10 +20,12 @@ class UserJoinServiceImplTest {
     UserJoinService userJoinService;
     UserDto userDto;
 
+    String sessionId = "testSessionId";
+
     @BeforeEach
     void insert() {
         this.userDto = createTestUser();
-        userJoinService.signUpUser(userDto);
+        userJoinService.signUpUser(userDto,sessionId);
     }
 
     @Test
@@ -34,7 +36,7 @@ class UserJoinServiceImplTest {
 
         //when
         Exception exception = assertThrows(Exception.class,
-                () -> userJoinService.checkUserIdDuplication(existUserId));
+                () -> userJoinService.checkUserIdDuplication(existUserId, sessionId));
 
         //then
         assertTrue(exception instanceof DataDuplicateKeyException);
@@ -47,7 +49,7 @@ class UserJoinServiceImplTest {
         String NotExistUserId = "not_exist";
 
         //when & then
-        assertDoesNotThrow(() -> userJoinService.checkUserIdDuplication(NotExistUserId));
+        assertDoesNotThrow(() -> userJoinService.checkUserIdDuplication(NotExistUserId, sessionId));
     }
 
     @Test
@@ -55,10 +57,11 @@ class UserJoinServiceImplTest {
     void givenExistNickname_whenCheckNicknameDuplication_thenThrowsException() {
         //given
         String existNickname = "imtest";
+        String sessionId = "sessionIdTest";
 
         //when & then
         Exception exception = assertThrows(Exception.class,
-                () -> userJoinService.checkNicknameDuplication(existNickname));
+                () -> userJoinService.checkNicknameDuplication(existNickname, sessionId));
 
         //then
         assertTrue(exception instanceof DataDuplicateKeyException);
@@ -69,9 +72,10 @@ class UserJoinServiceImplTest {
     void givenNotExistNickname_whenCheckNicknameDuplication_thenDoseNotThrowException() {
         //given
         String notExistNickname = "not_exist";
+        String sessionId = "sessionIdTest";
 
         //when & then
-        assertDoesNotThrow(() -> userJoinService.checkNicknameDuplication(notExistNickname));
+        assertDoesNotThrow(() -> userJoinService.checkNicknameDuplication(notExistNickname, sessionId));
     }
 
     @Test
@@ -81,7 +85,7 @@ class UserJoinServiceImplTest {
         UserDto testUser = createTestNewUser();
 
         //when & then
-        assertDoesNotThrow(() -> userJoinService.signUpUser(testUser));
+        assertDoesNotThrow(() -> userJoinService.signUpUser(testUser,sessionId));
     }
 
     @Test
@@ -92,7 +96,7 @@ class UserJoinServiceImplTest {
 
         // when
         Exception exception = assertThrows(Exception.class,
-                () -> userJoinService.signUpUser(testUser));
+                () -> userJoinService.signUpUser(testUser,sessionId));
 
         //then
         assertTrue(exception instanceof DataDuplicateKeyException);


### PR DESCRIPTION
### S(Situation)
* nickname, ID 중복 체크 시 동시에 여러 유저가 같은 ID, nickname에 대한 중복 체크 요청을 했을 시 모두에게 중복되지 않는 값으로 판단되어 중복체크 성공하는 이슈 발견.
* 추가로 중복체크 완료 후 다른 유저가 먼저  동일한 nickname,ID로 회원가입을 완료 했을 시 중복체크가 완료 되었음에도 중복값으로 회원가입이 완료되는 이슈 발견.
---
### B(Behavior)
* **B1** 
   *  user table에 중복 허용하지 않는 값인 ID, nickname 컬럼에 unique index를 걸어 중복 데이터 저장 방지
* **B2**   
   * B1의 결과가 해당 컬럼 값으로 조회시에는 성능상에 이점이 있으나, 쓰기를 위해 인덱스를 생성하며 불필요한 잠금을 사용하게 되며 성능에 영향을 미칠 수 있다는 문제 발견되어 Redis를 이용하여 캐싱하고, 3분간 해당 유저가 점유할 수 있도록 함
* **B3**
   * B2의 캐싱으로 인해 같은 사용자가 같은 값에 대해 중복요청을 여러번 할 경우, 해당 유저가 점유하기 위한 캐싱임에도 불구하고 사용하지 못하게 되는 현상이 발견되어 세션 ID와 같이 저장하여 해당 세션 ID가 점유할 수 있도록 함
   
 ### I(Impact)
* 불필요한 인덱스 사용으로 인한 데이터베이스의 성능 저하를 없애고, 동시에 동일한 데이터에 대한 중복 요청을 방어하고, 유저가 중복요청을 통해 중복 검사가 완료 된 데이터에 대한 값을 점유할 수 있어 회원 가입 동작까지 해당 데이터에 대한 무결성을 유지할 수 있게 되었음.