### PR TITLE
FEAT: [#37]공연장 정보 등록 API 구현

### DIFF
--- a/src/main/java/com/melodymarket/WebConfig.java
+++ b/src/main/java/com/melodymarket/WebConfig.java
@@ -1,0 +1,28 @@
+package com.melodymarket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.stream()
+                .filter(MappingJackson2HttpMessageConverter.class::isInstance)
+                .forEach(converter -> {
+                    MappingJackson2HttpMessageConverter jacksonConverter = (MappingJackson2HttpMessageConverter) converter;
+                    jacksonConverter.setDefaultCharset(StandardCharsets.UTF_8);
+                    List<MediaType> mediaTypes = new ArrayList<>(jacksonConverter.getSupportedMediaTypes());
+                    mediaTypes.add(0, new MediaType("application", "json", StandardCharsets.UTF_8));
+                    jacksonConverter.setSupportedMediaTypes(mediaTypes);
+                });
+    }
+}

--- a/src/main/java/com/melodymarket/application/theater/dto/TheaterDto.java
+++ b/src/main/java/com/melodymarket/application/theater/dto/TheaterDto.java
@@ -1,0 +1,21 @@
+package com.melodymarket.application.theater.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TheaterDto {
+    @NotBlank
+    String name;
+    @NotBlank
+    String location;
+    List<TheaterRoomDto> roomsInfo;
+
+}

--- a/src/main/java/com/melodymarket/application/theater/dto/TheaterRoomDto.java
+++ b/src/main/java/com/melodymarket/application/theater/dto/TheaterRoomDto.java
@@ -1,0 +1,16 @@
+package com.melodymarket.application.theater.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TheaterRoomDto {
+    String roomName;
+    List<TheaterSeatDto> seatData;
+}

--- a/src/main/java/com/melodymarket/application/theater/dto/TheaterSeatDto.java
+++ b/src/main/java/com/melodymarket/application/theater/dto/TheaterSeatDto.java
@@ -1,0 +1,15 @@
+package com.melodymarket.application.theater.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TheaterSeatDto {
+    Integer seatFloor;
+    Integer seatRow;
+    Integer seatNumber;
+}

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
@@ -1,0 +1,11 @@
+package com.melodymarket.application.theater.service;
+
+import com.melodymarket.application.theater.dto.TheaterDto;
+import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
+
+public interface ManageTheaterService {
+    TheaterResponseDto saveTheater(TheaterDto theaterDto);
+
+    boolean findByTheaterName(String theaterName);
+
+}

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -29,10 +29,7 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
         setTheaterPersistence(theater);
         try {
             theaterRepository.save(theater);
-            return TheaterResponseDto.builder()
-                    .name(theaterDto.getName())
-                    .location(theaterDto.getLocation())
-                    .build();
+            return TheaterResponseDto.from(theaterDto);
         } catch (DataAccessException e) {
             log.error("[saveTheater] 처리 중 오류가 발생했습니다={}", e.getMessage());
             throw new DataAccessCustomException("처리 중 오류가 발생했습니다");

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -2,6 +2,7 @@ package com.melodymarket.application.theater.service;
 
 import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.domain.theater.entity.TheaterEntity;
+import com.melodymarket.domain.theater.entity.TheaterRoomEntity;
 import com.melodymarket.infrastructure.exception.DataAccessCustomException;
 import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
@@ -48,9 +49,8 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
     }
 
     private void setTheaterPersistence(TheaterEntity theater) {
-        theater.getRooms().forEach(room -> {
-            room.setTheater(theater);
-            room.getSeats().forEach(seat -> seat.setTheaterRoom(room));
-        });
+        theater.associateTheaterWithRooms();
+        theater.getRooms().forEach(TheaterRoomEntity::associateRoomsWithSeats);
+
     }
 }

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -1,0 +1,59 @@
+package com.melodymarket.application.theater.service;
+
+import com.melodymarket.application.theater.dto.TheaterDto;
+import com.melodymarket.domain.theater.entity.TheaterEntity;
+import com.melodymarket.infrastructure.exception.DataAccessCustomException;
+import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
+import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Service
+@Slf4j
+public class ManageTheaterServiceImpl implements ManageTheaterService {
+
+    TheaterRepository theaterRepository;
+
+    @Override
+    public TheaterResponseDto saveTheater(TheaterDto theaterDto) {
+        if (findByTheaterName(theaterDto.getName())) {
+            throw new DataAccessCustomException("이미 등록 된 공연장 이름입니다.");
+        }
+        TheaterEntity theater = TheaterEntity.from(theaterDto);
+        setTheaterPersistence(theater);
+        try {
+            theaterRepository.save(theater);
+            return TheaterResponseDto.builder()
+                    .name(theaterDto.getName())
+                    .location(theaterDto.getLocation())
+                    .build();
+        } catch (DataAccessException e) {
+            log.error("[saveTheater] 처리 중 오류가 발생했습니다={}", e.getMessage());
+            throw new DataAccessCustomException("처리 중 오류가 발생했습니다");
+        }
+
+    }
+
+    @Override
+    public boolean findByTheaterName(String theaterName) {
+        try {
+            return theaterRepository.existsByName(theaterName);
+        } catch (DataAccessException e) {
+            log.error("[findByTheaterName] 처리 중 오류가 발생했습니다={}", e.getMessage());
+            throw new DataAccessCustomException("처리 중 오류가 발생했습니다");
+        }
+    }
+
+    private void setTheaterPersistence(TheaterEntity theater) {
+        theater.getRooms().forEach(room -> {
+            room.setTheater(theater);
+            room.getSeats().forEach(seat -> seat.setTheaterRoom(room));
+        });
+    }
+}

--- a/src/main/java/com/melodymarket/application/user/dto/UpdatePasswordDto.java
+++ b/src/main/java/com/melodymarket/application/user/dto/UpdatePasswordDto.java
@@ -1,4 +1,4 @@
-package com.melodymarket.application.dto;
+package com.melodymarket.application.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/com/melodymarket/application/user/dto/UpdateUserDto.java
+++ b/src/main/java/com/melodymarket/application/user/dto/UpdateUserDto.java
@@ -1,4 +1,4 @@
-package com.melodymarket.application.dto;
+package com.melodymarket.application.user.dto;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Email;

--- a/src/main/java/com/melodymarket/application/user/dto/UserDto.java
+++ b/src/main/java/com/melodymarket/application/user/dto/UserDto.java
@@ -1,4 +1,4 @@
-package com.melodymarket.application.dto;
+package com.melodymarket.application.user.dto;
 
 import com.melodymarket.domain.user.entity.UserEntity;
 import com.melodymarket.domain.user.model.UserModel;

--- a/src/main/java/com/melodymarket/application/user/service/CryptPasswordService.java
+++ b/src/main/java/com/melodymarket/application/user/service/CryptPasswordService.java
@@ -1,4 +1,4 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
 public interface CryptPasswordService {
     String encryptPassword(String password);

--- a/src/main/java/com/melodymarket/application/user/service/CryptPasswordServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/user/service/CryptPasswordServiceImpl.java
@@ -1,4 +1,4 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/melodymarket/application/user/service/LoginService.java
+++ b/src/main/java/com/melodymarket/application/user/service/LoginService.java
@@ -1,6 +1,6 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
-import com.melodymarket.infrastructure.repository.UserRepository;
+import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
 import com.melodymarket.infrastructure.security.MelodyUserDetails;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/melodymarket/application/user/service/UserAuthenticationInfoService.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserAuthenticationInfoService.java
@@ -1,0 +1,5 @@
+package com.melodymarket.application.user.service;
+
+public interface UserAuthenticationInfoService {
+    String getCurrentUserLoginId();
+}

--- a/src/main/java/com/melodymarket/application/user/service/UserAuthenticationInfoServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserAuthenticationInfoServiceImpl.java
@@ -1,0 +1,23 @@
+package com.melodymarket.application.user.service;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserAuthenticationInfoServiceImpl implements UserAuthenticationInfoService {
+    @Override
+    public String getCurrentUserLoginId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof UserDetails) {
+                return ((UserDetails) principal).getUsername();
+            } else if (principal instanceof String) {
+                return (String) principal;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/melodymarket/application/user/service/UserInfoManageService.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserInfoManageService.java
@@ -1,8 +1,8 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
-import com.melodymarket.application.dto.UpdatePasswordDto;
-import com.melodymarket.application.dto.UpdateUserDto;
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UpdatePasswordDto;
+import com.melodymarket.application.user.dto.UpdateUserDto;
+import com.melodymarket.application.user.dto.UserDto;
 
 public interface UserInfoManageService {
     UserDto getUserDetails(Long id);

--- a/src/main/java/com/melodymarket/application/user/service/UserInfoManageServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserInfoManageServiceImpl.java
@@ -1,12 +1,12 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
-import com.melodymarket.application.dto.UpdatePasswordDto;
-import com.melodymarket.application.dto.UpdateUserDto;
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UpdatePasswordDto;
+import com.melodymarket.application.user.dto.UpdateUserDto;
+import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.common.exception.PasswordMismatchException;
 import com.melodymarket.domain.user.entity.UserEntity;
 import com.melodymarket.infrastructure.exception.DataNotFoundException;
-import com.melodymarket.infrastructure.repository.UserRepository;
+import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;

--- a/src/main/java/com/melodymarket/application/user/service/UserJoinService.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserJoinService.java
@@ -1,6 +1,6 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UserDto;
 
 public interface UserJoinService {
     void checkUserIdDuplication(String loginId, String sessionId);

--- a/src/main/java/com/melodymarket/application/user/service/UserJoinServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserJoinServiceImpl.java
@@ -1,10 +1,10 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.domain.user.entity.UserEntity;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
 import com.melodymarket.infrastructure.redis.RedisService;
-import com.melodymarket.infrastructure.repository.UserRepository;
+import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;

--- a/src/main/java/com/melodymarket/common/dto/ResponseDto.java
+++ b/src/main/java/com/melodymarket/common/dto/ResponseDto.java
@@ -1,0 +1,18 @@
+package com.melodymarket.common.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@RequiredArgsConstructor(staticName = "of")
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class ResponseDto<D> {
+    HttpStatus resultCode;
+    String message;
+    D data;
+}

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowEntity.java
@@ -3,14 +3,14 @@ package com.melodymarket.domain.show.entity;
 import com.melodymarket.domain.theater.entity.TheaterEntity;
 import com.melodymarket.domain.user.entity.UserEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Table(name = "shows")
 public class ShowEntity {
     @Id
@@ -34,4 +34,13 @@ public class ShowEntity {
     @JoinColumn(name = "theater_id")
     private TheaterEntity theater;
 
+    @Builder
+    public ShowEntity(String showName, String director, String reserveStartDate, Integer price, UserEntity user, TheaterEntity theater) {
+        this.showName = showName;
+        this.director = director;
+        this.reserveStartDate = reserveStartDate;
+        this.price = price;
+        this.user = user;
+        this.theater = theater;
+    }
 }

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowEntity.java
@@ -1,0 +1,37 @@
+package com.melodymarket.domain.show.entity;
+
+import com.melodymarket.domain.theater.entity.TheaterEntity;
+import com.melodymarket.domain.user.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "shows")
+public class ShowEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private String showName;
+    @Column
+    private String director;
+    @Column
+    private String reserveStartDate;
+
+    @Column
+    private Integer price;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    @OneToOne
+    @JoinColumn(name="theater_id")
+    private TheaterEntity theater;
+
+}

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowEntity.java
@@ -31,7 +31,7 @@ public class ShowEntity {
     private UserEntity user;
 
     @OneToOne
-    @JoinColumn(name="theater_id")
+    @JoinColumn(name = "theater_id")
     private TheaterEntity theater;
 
 }

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowScheduleEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowScheduleEntity.java
@@ -16,16 +16,16 @@ public class ShowScheduleEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
-    @JoinColumn(name="show_id")
+    @JoinColumn(name = "show_id")
     private ShowEntity showList;
     @Column
     private String showDate;
 
     @OneToOne
-    @JoinColumn(name="theater_reserve_id")
+    @JoinColumn(name = "theater_reserve_id")
     private TheaterReserveEntity theaterReserve;
     @ManyToOne
-    @JoinColumn(name="show_seat_id")
+    @JoinColumn(name = "show_seat_id")
     private ShowSeatEntity showSeat;
 
 }

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowScheduleEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowScheduleEntity.java
@@ -2,13 +2,13 @@ package com.melodymarket.domain.show.entity;
 
 import com.melodymarket.domain.theater.entity.TheaterReserveEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "show_schedule")
 public class ShowScheduleEntity {
@@ -28,4 +28,11 @@ public class ShowScheduleEntity {
     @JoinColumn(name = "show_seat_id")
     private ShowSeatEntity showSeat;
 
+    @Builder
+    public ShowScheduleEntity(ShowEntity showList, String showDate, TheaterReserveEntity theaterReserve, ShowSeatEntity showSeat) {
+        this.showList = showList;
+        this.showDate = showDate;
+        this.theaterReserve = theaterReserve;
+        this.showSeat = showSeat;
+    }
 }

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowScheduleEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowScheduleEntity.java
@@ -1,0 +1,31 @@
+package com.melodymarket.domain.show.entity;
+
+import com.melodymarket.domain.theater.entity.TheaterReserveEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "show_schedule")
+public class ShowScheduleEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name="show_id")
+    private ShowEntity showList;
+    @Column
+    private String showDate;
+
+    @OneToOne
+    @JoinColumn(name="theater_reserve_id")
+    private TheaterReserveEntity theaterReserve;
+    @ManyToOne
+    @JoinColumn(name="show_seat_id")
+    private ShowSeatEntity showSeat;
+
+}

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowSeatEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowSeatEntity.java
@@ -1,0 +1,23 @@
+package com.melodymarket.domain.show.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "show_seat")
+public class ShowSeatEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @OneToMany(mappedBy = "showSeat")
+    private List<ShowScheduleEntity> showSchedule;
+
+    private Long seatId;
+}

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowSeatEntity.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowSeatEntity.java
@@ -6,10 +6,7 @@ import lombok.*;
 import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "show_seat")
 public class ShowSeatEntity {
@@ -18,6 +15,12 @@ public class ShowSeatEntity {
     private Long id;
     @OneToMany(mappedBy = "showSeat")
     private List<ShowScheduleEntity> showSchedule;
-
+    @Column
     private Long seatId;
+
+    @Builder
+    public ShowSeatEntity(List<ShowScheduleEntity> showSchedule, Long seatId) {
+        this.showSchedule = showSchedule;
+        this.seatId = seatId;
+    }
 }

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterEntity.java
@@ -1,0 +1,37 @@
+package com.melodymarket.domain.theater.entity;
+
+import com.melodymarket.application.theater.dto.TheaterDto;
+import com.melodymarket.domain.show.entity.ShowEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "theater")
+public class TheaterEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private String name;
+    @Column
+    private String location;
+    @OneToOne(mappedBy = "theater")
+    private ShowEntity showList;
+    @OneToMany(mappedBy = "theater",cascade = CascadeType.ALL)
+    private List<TheaterRoomEntity> rooms;
+    public static TheaterEntity from(TheaterDto theaterDto) {
+        return TheaterEntity
+                .builder()
+                .name(theaterDto.getName())
+                .location(theaterDto.getLocation())
+                .rooms(TheaterRoomEntity.from(theaterDto.getRoomsInfo()))
+                .build();
+    }
+}

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterEntity.java
@@ -24,8 +24,9 @@ public class TheaterEntity {
     private String location;
     @OneToOne(mappedBy = "theater")
     private ShowEntity showList;
-    @OneToMany(mappedBy = "theater",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "theater", cascade = CascadeType.ALL)
     private List<TheaterRoomEntity> rooms;
+
     public static TheaterEntity from(TheaterDto theaterDto) {
         return TheaterEntity
                 .builder()

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterEntity.java
@@ -3,16 +3,16 @@ package com.melodymarket.domain.theater.entity;
 import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.domain.show.entity.ShowEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Table(name = "theater")
 public class TheaterEntity {
     @Id
@@ -24,15 +24,26 @@ public class TheaterEntity {
     private String location;
     @OneToOne(mappedBy = "theater")
     private ShowEntity showList;
-    @OneToMany(mappedBy = "theater", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "theater", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<TheaterRoomEntity> rooms;
 
+    @Builder
+    public TheaterEntity(String name, String location, ShowEntity showList, List<TheaterRoomEntity> rooms) {
+        this.name = name;
+        this.location = location;
+        this.showList = showList;
+        this.rooms = rooms;
+    }
+
     public static TheaterEntity from(TheaterDto theaterDto) {
-        return TheaterEntity
-                .builder()
+        return TheaterEntity.builder()
                 .name(theaterDto.getName())
                 .location(theaterDto.getLocation())
                 .rooms(TheaterRoomEntity.from(theaterDto.getRoomsInfo()))
                 .build();
+    }
+
+    public void associateTheaterWithRooms() {
+        this.getRooms().forEach(room -> room.setTheater(this));
     }
 }

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserveEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserveEntity.java
@@ -15,7 +15,7 @@ public class TheaterReserveEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @OneToOne(mappedBy = "theaterReserve",cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "theaterReserve", cascade = CascadeType.ALL)
     private ShowScheduleEntity showSchedule;
     @Column
     private String reserveDate;

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserveEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserveEntity.java
@@ -2,14 +2,14 @@ package com.melodymarket.domain.theater.entity;
 
 import com.melodymarket.domain.show.entity.ShowScheduleEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Table(name = "theater_reserve")
 public class TheaterReserveEntity {
     @Id
@@ -19,4 +19,10 @@ public class TheaterReserveEntity {
     private ShowScheduleEntity showSchedule;
     @Column
     private String reserveDate;
+
+    @Builder
+    public TheaterReserveEntity(ShowScheduleEntity showSchedule, String reserveDate) {
+        this.showSchedule = showSchedule;
+        this.reserveDate = reserveDate;
+    }
 }

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserveEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserveEntity.java
@@ -1,0 +1,22 @@
+package com.melodymarket.domain.theater.entity;
+
+import com.melodymarket.domain.show.entity.ShowScheduleEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "theater_reserve")
+public class TheaterReserveEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @OneToOne(mappedBy = "theaterReserve",cascade = CascadeType.ALL)
+    private ShowScheduleEntity showSchedule;
+    @Column
+    private String reserveDate;
+}

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoomEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoomEntity.java
@@ -23,7 +23,7 @@ public class TheaterRoomEntity {
     private TheaterEntity theater;
     @Column
     private String name;
-    @OneToMany(mappedBy = "theaterRoom",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "theaterRoom", cascade = CascadeType.ALL)
     private List<TheaterSeatEntity> seats;
 
     public static List<TheaterRoomEntity> from(List<TheaterRoomDto> theaterRoomDto) {

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoomEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoomEntity.java
@@ -1,0 +1,38 @@
+package com.melodymarket.domain.theater.entity;
+
+import com.melodymarket.application.theater.dto.TheaterRoomDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "theater_room")
+public class TheaterRoomEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "theater_id")
+    private TheaterEntity theater;
+    @Column
+    private String name;
+    @OneToMany(mappedBy = "theaterRoom",cascade = CascadeType.ALL)
+    private List<TheaterSeatEntity> seats;
+
+    public static List<TheaterRoomEntity> from(List<TheaterRoomDto> theaterRoomDto) {
+        return theaterRoomDto.stream()
+                .map(roomDto -> TheaterRoomEntity.builder()
+                        .name(roomDto.getRoomName())
+                        .seats(TheaterSeatEntity.from(roomDto.getSeatData()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoomEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoomEntity.java
@@ -2,17 +2,16 @@ package com.melodymarket.domain.theater.entity;
 
 import com.melodymarket.application.theater.dto.TheaterRoomDto;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Table(name = "theater_room")
 public class TheaterRoomEntity {
     @Id
@@ -23,8 +22,20 @@ public class TheaterRoomEntity {
     private TheaterEntity theater;
     @Column
     private String name;
+
     @OneToMany(mappedBy = "theaterRoom", cascade = CascadeType.ALL)
     private List<TheaterSeatEntity> seats;
+
+    protected void setTheater(TheaterEntity theater) {
+        this.theater = theater;
+    }
+
+    @Builder
+    public TheaterRoomEntity(TheaterEntity theater, String name, List<TheaterSeatEntity> seats) {
+        this.theater = theater;
+        this.name = name;
+        this.seats = seats;
+    }
 
     public static List<TheaterRoomEntity> from(List<TheaterRoomDto> theaterRoomDto) {
         return theaterRoomDto.stream()
@@ -32,7 +43,11 @@ public class TheaterRoomEntity {
                         .name(roomDto.getRoomName())
                         .seats(TheaterSeatEntity.from(roomDto.getSeatData()))
                         .build())
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    public void associateRoomsWithSeats() {
+        this.getSeats().forEach(seat -> seat.setTheaterRoom(this));
     }
 
 }

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterSeatEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterSeatEntity.java
@@ -1,0 +1,41 @@
+package com.melodymarket.domain.theater.entity;
+
+import com.melodymarket.application.theater.dto.TheaterSeatDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "seat")
+public class TheaterSeatEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "theater_room_id")
+    private TheaterRoomEntity theaterRoom;
+    @Column
+    private Integer seatFloor;
+    @Column
+    private Integer seatRow;
+    @Column
+    private Integer seatNumber;
+
+    public static List<TheaterSeatEntity> from(List<TheaterSeatDto> seatDtos) {
+        return seatDtos.stream()
+                .map(seatDto -> TheaterSeatEntity.builder()
+                        .seatFloor(seatDto.getSeatFloor())
+                        .seatRow(seatDto.getSeatRow())
+                        .seatNumber(seatDto.getSeatNumber())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterSeatEntity.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterSeatEntity.java
@@ -2,17 +2,17 @@ package com.melodymarket.domain.theater.entity;
 
 import com.melodymarket.application.theater.dto.TheaterSeatDto;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "seat")
 public class TheaterSeatEntity {
     @Id
@@ -27,6 +27,18 @@ public class TheaterSeatEntity {
     private Integer seatRow;
     @Column
     private Integer seatNumber;
+
+    protected void setTheaterRoom(TheaterRoomEntity theaterRoom) {
+        this.theaterRoom = theaterRoom;
+    }
+
+    @Builder
+    public TheaterSeatEntity(TheaterRoomEntity theaterRoom, Integer seatFloor, Integer seatRow, Integer seatNumber) {
+        this.theaterRoom = theaterRoom;
+        this.seatFloor = seatFloor;
+        this.seatRow = seatRow;
+        this.seatNumber = seatNumber;
+    }
 
     public static List<TheaterSeatEntity> from(List<TheaterSeatDto> seatDtos) {
         return seatDtos.stream()

--- a/src/main/java/com/melodymarket/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/melodymarket/domain/user/entity/UserEntity.java
@@ -1,7 +1,7 @@
 package com.melodymarket.domain.user.entity;
 
-import com.melodymarket.application.dto.UpdateUserDto;
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UpdateUserDto;
+import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.domain.user.enums.MembershipLevelEnum;
 import com.melodymarket.util.DateFormattingUtil;
 import jakarta.persistence.*;

--- a/src/main/java/com/melodymarket/domain/user/model/UserModel.java
+++ b/src/main/java/com/melodymarket/domain/user/model/UserModel.java
@@ -1,6 +1,6 @@
 package com.melodymarket.domain.user.model;
 
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.domain.user.enums.MembershipLevelEnum;
 import com.melodymarket.util.DateFormattingUtil;
 import lombok.Builder;

--- a/src/main/java/com/melodymarket/infrastructure/exception/DataAccessCustomException.java
+++ b/src/main/java/com/melodymarket/infrastructure/exception/DataAccessCustomException.java
@@ -1,0 +1,9 @@
+package com.melodymarket.infrastructure.exception;
+
+import org.springframework.dao.DataAccessException;
+
+public class DataAccessCustomException extends DataAccessException {
+    public DataAccessCustomException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/melodymarket/infrastructure/exception/DatabaseExceptionHandler.java
+++ b/src/main/java/com/melodymarket/infrastructure/exception/DatabaseExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.melodymarket.infrastructure.exception;
 
+import com.melodymarket.common.dto.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -21,5 +22,12 @@ public class DatabaseExceptionHandler {
                 .status(HttpStatus.NOT_FOUND)
                 .body(ex.getMessage());
 
+    }
+
+    @ExceptionHandler(DataAccessCustomException.class)
+    public ResponseDto<Object> handleDataAccessException(DataAccessCustomException ex) {
+        return ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR,
+                ex.getMessage(),
+                "");
     }
 }

--- a/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
+++ b/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
@@ -1,0 +1,11 @@
+package com.melodymarket.infrastructure.jpa.theater.repository;
+
+import com.melodymarket.domain.theater.entity.TheaterEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TheaterRepository extends JpaRepository<TheaterEntity, Long> {
+    @Override
+    <S extends TheaterEntity> S save(S theaterEntity);
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/melodymarket/infrastructure/jpa/user/repository/UserRepository.java
+++ b/src/main/java/com/melodymarket/infrastructure/jpa/user/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package com.melodymarket.infrastructure.repository;
+package com.melodymarket.infrastructure.jpa.user.repository;
 
 import com.melodymarket.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/melodymarket/infrastructure/mybatis/mapper/UserMapper.java
+++ b/src/main/java/com/melodymarket/infrastructure/mybatis/mapper/UserMapper.java
@@ -1,6 +1,6 @@
 package com.melodymarket.infrastructure.mybatis.mapper;
 
-import com.melodymarket.application.dto.UpdateUserDto;
+import com.melodymarket.application.user.dto.UpdateUserDto;
 import com.melodymarket.domain.user.model.UserModel;
 import org.apache.ibatis.annotations.Mapper;
 

--- a/src/main/java/com/melodymarket/presentation/admin/controller/JoinUserController.java
+++ b/src/main/java/com/melodymarket/presentation/admin/controller/JoinUserController.java
@@ -1,8 +1,8 @@
 package com.melodymarket.presentation.admin.controller;
 
-import com.melodymarket.application.dto.UserDto;
-import com.melodymarket.application.service.UserJoinService;
-import com.melodymarket.application.service.UserJoinServiceImpl;
+import com.melodymarket.application.user.dto.UserDto;
+import com.melodymarket.application.user.service.UserJoinService;
+import com.melodymarket.application.user.service.UserJoinServiceImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;

--- a/src/main/java/com/melodymarket/presentation/admin/controller/ManageUserController.java
+++ b/src/main/java/com/melodymarket/presentation/admin/controller/ManageUserController.java
@@ -1,9 +1,9 @@
 package com.melodymarket.presentation.admin.controller;
 
-import com.melodymarket.application.dto.UpdatePasswordDto;
-import com.melodymarket.application.dto.UpdateUserDto;
-import com.melodymarket.application.service.UserInfoManageService;
-import com.melodymarket.application.service.UserInfoManageServiceImpl;
+import com.melodymarket.application.user.dto.UpdatePasswordDto;
+import com.melodymarket.application.user.dto.UpdateUserDto;
+import com.melodymarket.application.user.service.UserInfoManageService;
+import com.melodymarket.application.user.service.UserInfoManageServiceImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
+++ b/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
@@ -1,0 +1,35 @@
+package com.melodymarket.presentation.theater.controller;
+
+import com.melodymarket.application.theater.dto.TheaterDto;
+import com.melodymarket.application.theater.service.ManageTheaterService;
+import com.melodymarket.application.theater.service.ManageTheaterServiceImpl;
+import com.melodymarket.common.dto.ResponseDto;
+import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/theater")
+public class ManageTheaterController {
+
+    ManageTheaterService manageTheaterService;
+
+    public ManageTheaterController(ManageTheaterServiceImpl manageTheaterServiceImpl) {
+        this.manageTheaterService = manageTheaterServiceImpl;
+    }
+
+    @PostMapping("/add")
+    public ResponseEntity<ResponseDto<TheaterResponseDto>> addTheater(@RequestBody @Validated TheaterDto theaterDto) {
+
+        return new ResponseEntity<>(ResponseDto.of(HttpStatus.OK,
+                "공연장 등록이 완료되었습니다.",
+                manageTheaterService.saveTheater(theaterDto)), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
+++ b/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
@@ -1,0 +1,9 @@
+package com.melodymarket.presentation.theater.dto;
+
+import lombok.Builder;
+
+@Builder
+public class TheaterResponseDto {
+    String name;
+    String location;
+}

--- a/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
+++ b/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
@@ -1,9 +1,17 @@
 package com.melodymarket.presentation.theater.dto;
 
+import com.melodymarket.application.theater.dto.TheaterDto;
 import lombok.Builder;
 
 @Builder
 public class TheaterResponseDto {
     String name;
     String location;
+
+    public static TheaterResponseDto from(TheaterDto theaterDto) {
+        return TheaterResponseDto.builder()
+                .name(theaterDto.getName())
+                .location(theaterDto.getLocation())
+                .build();
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,7 @@ spring:
     hibernate:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+    show-sql: true
   data:
     redis:
       host: localhost

--- a/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
@@ -1,0 +1,90 @@
+package com.melodymarket.application.theater.service;
+
+import com.melodymarket.application.theater.dto.TheaterDto;
+import com.melodymarket.application.theater.dto.TheaterRoomDto;
+import com.melodymarket.application.theater.dto.TheaterSeatDto;
+import com.melodymarket.infrastructure.exception.DataAccessCustomException;
+import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@DisplayName("공연장 관리 서비스 테스트")
+class TheaterManageServiceImplTest {
+    @Autowired
+    ManageTheaterService manageTheaterService;
+    @Autowired
+    TheaterRepository theaterRepository;
+    TheaterDto theaterDto;
+
+    @BeforeEach
+    void insert() {
+        this.theaterDto = createTestTheater("테스트 공연장");
+        manageTheaterService.saveTheater(theaterDto);
+    }
+
+    @Test
+    @DisplayName("새로운 공연장 등록 정상 테스트")
+    void givenTheaterInfo_whenAddTheaterInfo_thenSuccess() {
+        //given
+        TheaterDto theaterTestDto = createTestTheater("새로운공연장");
+
+        //when & then
+        assertDoesNotThrow(() -> manageTheaterService.saveTheater(theaterTestDto));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 공연장 이름 등록 예외 발생 테스트")
+    void givenExistTheaterName_whenAddTheaterInfo_thenThrowException() {
+        //given
+        TheaterDto theaterTestDto = theaterDto;
+
+        //when
+        Exception exception = assertThrows(Exception.class, () -> manageTheaterService.saveTheater(theaterTestDto));
+
+        //then
+        assertTrue(exception instanceof DataAccessCustomException);
+    }
+
+    private TheaterDto createTestTheater(String name) {
+        return TheaterDto.builder()
+                .name(name)
+                .location("위치")
+                .roomsInfo(createTestTheaterRooms())
+                .build();
+    }
+
+    private List<TheaterRoomDto> createTestTheaterRooms() {
+        List<TheaterRoomDto> roomDtoList = new ArrayList<>();
+        roomDtoList.add(
+                TheaterRoomDto.builder()
+                        .roomName("test hall")
+                        .seatData(createTestTheaterSeats())
+                        .build()
+        );
+        return roomDtoList;
+    }
+
+    private List<TheaterSeatDto> createTestTheaterSeats() {
+        List<TheaterSeatDto> seatDtoList = new ArrayList<>();
+        seatDtoList.add(
+                TheaterSeatDto.builder()
+                        .seatFloor(1)
+                        .seatRow(1)
+                        .seatNumber(1)
+                        .build()
+        );
+        return seatDtoList;
+    }
+
+}

--- a/src/test/java/com/melodymarket/application/user/service/UserInfoManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/user/service/UserInfoManageServiceImplTest.java
@@ -1,12 +1,12 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
-import com.melodymarket.application.dto.UpdatePasswordDto;
-import com.melodymarket.application.dto.UpdateUserDto;
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UpdatePasswordDto;
+import com.melodymarket.application.user.dto.UpdateUserDto;
+import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.common.exception.PasswordMismatchException;
 import com.melodymarket.domain.user.entity.UserEntity;
 import com.melodymarket.infrastructure.exception.DataNotFoundException;
-import com.melodymarket.infrastructure.repository.UserRepository;
+import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/melodymarket/application/user/service/UserJoinServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/user/service/UserJoinServiceImplTest.java
@@ -1,6 +1,6 @@
-package com.melodymarket.application.service;
+package com.melodymarket.application.user.service;
 
-import com.melodymarket.application.dto.UserDto;
+import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/melodymarket/presentation/admin/controller/JoinUserControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/admin/controller/JoinUserControllerTest.java
@@ -1,8 +1,8 @@
 package com.melodymarket.presentation.admin.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.melodymarket.application.dto.UserDto;
-import com.melodymarket.application.service.UserJoinServiceImpl;
+import com.melodymarket.application.user.dto.UserDto;
+import com.melodymarket.application.user.service.UserJoinServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,6 +34,7 @@ class JoinUserControllerTest {
 
     @MockBean
     UserJoinServiceImpl userJoinService;
+
 
     @Autowired
     WebApplicationContext webApplicationContext;

--- a/src/test/java/com/melodymarket/presentation/admin/controller/ManageUserControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/admin/controller/ManageUserControllerTest.java
@@ -1,10 +1,10 @@
 package com.melodymarket.presentation.admin.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.melodymarket.application.dto.UpdatePasswordDto;
-import com.melodymarket.application.dto.UpdateUserDto;
-import com.melodymarket.application.dto.UserDto;
-import com.melodymarket.application.service.UserInfoManageServiceImpl;
+import com.melodymarket.application.user.dto.UpdatePasswordDto;
+import com.melodymarket.application.user.dto.UpdateUserDto;
+import com.melodymarket.application.user.dto.UserDto;
+import com.melodymarket.application.user.service.UserInfoManageServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
@@ -1,0 +1,99 @@
+package com.melodymarket.presentation.theater.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.melodymarket.application.theater.dto.TheaterDto;
+import com.melodymarket.application.theater.dto.TheaterRoomDto;
+import com.melodymarket.application.theater.dto.TheaterSeatDto;
+import com.melodymarket.application.theater.service.ManageTheaterServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("공연장 API 테스트")
+@WithMockUser(roles = "USER")
+@WebMvcTest(ManageTheaterController.class)
+class ManageTheaterControllerTest {
+
+    @MockBean
+    ManageTheaterServiceImpl manageTheaterService;
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ManageTheaterController manageTheaterController;
+    @Autowired
+    WebApplicationContext webApplicationContext;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(post("/**").with(csrf()))
+                .build();
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("[POST] 공연장 등록 API 테스트")
+    void givenTestTheater_whenAddTheater_thenSuccess() throws Exception {
+        //given
+        TheaterDto testTheater = createTestTheater();
+        //json 형식으로 convert
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(testTheater);
+
+        //when
+        mockMvc.perform(post("/v1/theater/add")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                //then
+                .andExpect(status().isOk());
+    }
+
+    private TheaterDto createTestTheater() {
+        return TheaterDto.builder()
+                .name("공연장")
+                .location("위치")
+                .roomsInfo(createTestTheaterRooms())
+                .build();
+    }
+
+    private List<TheaterRoomDto> createTestTheaterRooms() {
+        List<TheaterRoomDto> roomDtoList = new ArrayList<>();
+        roomDtoList.add(
+                TheaterRoomDto.builder()
+                        .roomName("test hall")
+                        .seatData(createTestTheaterSeats())
+                        .build()
+        );
+        return roomDtoList;
+    }
+
+    private List<TheaterSeatDto> createTestTheaterSeats() {
+        List<TheaterSeatDto> seatDtoList = new ArrayList<>();
+        seatDtoList.add(
+                TheaterSeatDto.builder()
+                        .seatFloor(1)
+                        .seatRow(1)
+                        .seatNumber(1)
+                        .build()
+        );
+        return seatDtoList;
+    }
+}


### PR DESCRIPTION
* 공연장 등록 시 필요한 Entity 객체 생성 완료
* ResponseDto로 성공 여부 전달하도록 추가 완료
* 동일한 공연장 이름으로 등록되지 않도록 예외 추가 
* 공연장 데이터베이스에 저장하기 위한 레포지토리 추가 완료
* 테스트 정상 수행 확인 완료

close #37 