### PR TITLE
[#43] ResponseDto로 응답하도록 리팩터링

### DIFF
--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -3,7 +3,7 @@ package com.melodymarket.application.theater.service;
 import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.domain.theater.entity.TheaterEntity;
 import com.melodymarket.domain.theater.entity.TheaterRoomEntity;
-import com.melodymarket.infrastructure.exception.DataAccessCustomException;
+import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
 import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 import lombok.AccessLevel;
@@ -24,7 +24,7 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
     @Override
     public TheaterResponseDto saveTheater(TheaterDto theaterDto) {
         if (findByTheaterName(theaterDto.getName())) {
-            throw new DataAccessCustomException("이미 등록 된 공연장 이름입니다.");
+            throw new DataDuplicateKeyException("이미 등록 된 공연장 이름입니다.");
         }
         TheaterEntity theater = TheaterEntity.from(theaterDto);
         setTheaterPersistence(theater);
@@ -33,7 +33,7 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
             return TheaterResponseDto.from(theaterDto);
         } catch (DataAccessException e) {
             log.error("[saveTheater] 처리 중 오류가 발생했습니다={}", e.getMessage());
-            throw new DataAccessCustomException("처리 중 오류가 발생했습니다");
+            throw e;
         }
 
     }
@@ -44,7 +44,7 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
             return theaterRepository.existsByName(theaterName);
         } catch (DataAccessException e) {
             log.error("[findByTheaterName] 처리 중 오류가 발생했습니다={}", e.getMessage());
-            throw new DataAccessCustomException("처리 중 오류가 발생했습니다");
+            throw e;
         }
     }
 

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -1,8 +1,8 @@
 package com.melodymarket.application.theater.service;
 
 import com.melodymarket.application.theater.dto.TheaterDto;
-import com.melodymarket.domain.theater.entity.TheaterEntity;
-import com.melodymarket.domain.theater.entity.TheaterRoomEntity;
+import com.melodymarket.domain.theater.entity.Theater;
+import com.melodymarket.domain.theater.entity.TheaterRoom;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
 import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
@@ -10,7 +10,6 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -26,31 +25,20 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
         if (findByTheaterName(theaterDto.getName())) {
             throw new DataDuplicateKeyException("이미 등록 된 공연장 이름입니다.");
         }
-        TheaterEntity theater = TheaterEntity.from(theaterDto);
+        Theater theater = Theater.from(theaterDto);
         setTheaterPersistence(theater);
-        try {
-            theaterRepository.save(theater);
-            return TheaterResponseDto.from(theaterDto);
-        } catch (DataAccessException e) {
-            log.error("[saveTheater] 처리 중 오류가 발생했습니다={}", e.getMessage());
-            throw e;
-        }
-
+        theaterRepository.save(theater);
+        return TheaterResponseDto.from(theaterDto);
     }
 
     @Override
     public boolean findByTheaterName(String theaterName) {
-        try {
-            return theaterRepository.existsByName(theaterName);
-        } catch (DataAccessException e) {
-            log.error("[findByTheaterName] 처리 중 오류가 발생했습니다={}", e.getMessage());
-            throw e;
-        }
+        return theaterRepository.existsByName(theaterName);
     }
 
-    private void setTheaterPersistence(TheaterEntity theater) {
+    private void setTheaterPersistence(Theater theater) {
         theater.associateTheaterWithRooms();
-        theater.getRooms().forEach(TheaterRoomEntity::associateRoomsWithSeats);
+        theater.getRooms().forEach(TheaterRoom::associateRoomsWithSeats);
 
     }
 }

--- a/src/main/java/com/melodymarket/application/user/dto/UserDto.java
+++ b/src/main/java/com/melodymarket/application/user/dto/UserDto.java
@@ -1,6 +1,5 @@
 package com.melodymarket.application.user.dto;
 
-import com.melodymarket.domain.user.entity.UserEntity;
 import com.melodymarket.domain.user.model.UserModel;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -46,19 +45,6 @@ public class UserDto {
                 .birthDate(userModel.getBirthDate())
                 .email(userModel.getEmail())
                 .membershipLevel(userModel.getMembershipLevel())
-                .build();
-    }
-
-    public static UserDto from(UserEntity userEntity) {
-        return UserDto
-                .builder()
-                .loginId(userEntity.getLoginId())
-                .username(userEntity.getUsername())
-                .nickname(userEntity.getNickname())
-                .userPassword(userEntity.getUserPassword())
-                .birthDate(userEntity.getBirthDate())
-                .email(userEntity.getEmail())
-                .membershipLevel(userEntity.getMembershipLevel())
                 .build();
     }
 

--- a/src/main/java/com/melodymarket/application/user/service/UserInfoManageService.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserInfoManageService.java
@@ -2,11 +2,14 @@ package com.melodymarket.application.user.service;
 
 import com.melodymarket.application.user.dto.UpdatePasswordDto;
 import com.melodymarket.application.user.dto.UpdateUserDto;
-import com.melodymarket.application.user.dto.UserDto;
+import com.melodymarket.presentation.admin.dto.UserResponseDto;
 
 public interface UserInfoManageService {
-    UserDto getUserDetails(Long id);
+    UserResponseDto getUserDetails(Long id);
+
     void modifyUserPassword(Long id, UpdatePasswordDto updatePasswordDto);
+
     void modifyUserDetails(Long id, UpdateUserDto updateUserDto);
+
     void deleteUser(Long id, String password);
 }

--- a/src/main/java/com/melodymarket/application/user/service/UserInfoManageServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserInfoManageServiceImpl.java
@@ -4,7 +4,7 @@ import com.melodymarket.application.user.dto.UpdatePasswordDto;
 import com.melodymarket.application.user.dto.UpdateUserDto;
 import com.melodymarket.common.exception.PasswordMismatchException;
 import com.melodymarket.common.exception.PasswordSameException;
-import com.melodymarket.domain.user.entity.UserEntity;
+import com.melodymarket.domain.user.entity.User;
 import com.melodymarket.infrastructure.exception.DataNotFoundException;
 import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
 import com.melodymarket.presentation.admin.dto.UserResponseDto;
@@ -31,17 +31,17 @@ public class UserInfoManageServiceImpl implements UserInfoManageService {
 
     @Override
     public void modifyUserPassword(Long id, UpdatePasswordDto updatePasswordDto) {
-        UserEntity userEntity = getUserEntity(id);
+        User user = getUserEntity(id);
         if (!cryptPasswordService.isPasswordMatch(updatePasswordDto.getOldPassword(),
-                userEntity.getUserPassword())) {
+                user.getUserPassword())) {
             throw new PasswordMismatchException("비밀번호가 일치하지 않습니다.");
         } else if (cryptPasswordService.isPasswordMatch(updatePasswordDto.getNewPassword(),
-                userEntity.getUserPassword())) {
+                user.getUserPassword())) {
             throw new PasswordSameException("새 비밀번호는 현재 비밀번호와 다르게 설정해야 합니다.");
         }
 
-        userEntity.changePassword(updatePasswordDto.getNewPassword(), cryptPasswordService);
-        userRepository.save(userEntity);
+        user.changePassword(updatePasswordDto.getNewPassword(), cryptPasswordService);
+        userRepository.save(user);
     }
 
     @Override
@@ -52,15 +52,15 @@ public class UserInfoManageServiceImpl implements UserInfoManageService {
 
     @Override
     public void deleteUser(Long id, String password) {
-        UserEntity userEntity = getUserEntity(id);
+        User user = getUserEntity(id);
         if (!cryptPasswordService.isPasswordMatch(password,
-                userEntity.getUserPassword())) {
+                user.getUserPassword())) {
             throw new PasswordMismatchException("비밀번호가 일치하지 않습니다.");
         }
         userRepository.deleteById(id);
     }
 
-    public UserEntity getUserEntity(Long id) {
+    public User getUserEntity(Long id) {
         return userRepository.findById(id).orElseThrow(() -> new DataNotFoundException("유저 정보를 조회할 수 없습니다."));
     }
 

--- a/src/main/java/com/melodymarket/application/user/service/UserJoinServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/user/service/UserJoinServiceImpl.java
@@ -1,7 +1,7 @@
 package com.melodymarket.application.user.service;
 
 import com.melodymarket.application.user.dto.UserDto;
-import com.melodymarket.domain.user.entity.UserEntity;
+import com.melodymarket.domain.user.entity.User;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
 import com.melodymarket.infrastructure.redis.RedisService;
 import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
@@ -48,12 +48,12 @@ public class UserJoinServiceImpl implements UserJoinService {
 
     @Override
     public void signUpUser(UserDto userDto, String sessionId) {
-        UserEntity userEntity = UserEntity.from(userDto, cryptPasswordService.encryptPassword(userDto.getUserPassword()));
+        User user = User.from(userDto, cryptPasswordService.encryptPassword(userDto.getUserPassword()));
 
         checkUserIdDuplication(userDto.getLoginId(), sessionId);
         checkNicknameDuplication(userDto.getNickname(), sessionId);
         try {
-            userRepository.save(userEntity);
+            userRepository.save(user);
         } catch (DataIntegrityViolationException e) {
             log.error("중복 데이터 회원가입 시도 ={}", userDto);
             throw new DataDuplicateKeyException("이미 가입 된 회원 정보 입니다.");

--- a/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.melodymarket.common.exception;
 
 import com.melodymarket.common.dto.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -12,6 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -39,5 +42,19 @@ public class GlobalExceptionHandler {
     public ResponseDto<String> handlePasswordMissMatchException(PasswordMismatchException ex) {
 
         return ResponseDto.of(HttpStatus.NOT_MODIFIED, ex.getMessage(), null);
+    }
+
+    @ExceptionHandler(PasswordSameException.class)
+    public ResponseDto<String> handlePasswordSameException(PasswordSameException ex) {
+
+        return ResponseDto.of(HttpStatus.NOT_MODIFIED, ex.getMessage(), null);
+    }
+
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseDto<String> handleDataAccessException(DataAccessException ex) {
+        log.error("[handleDataAccessException] 데이터 처리 중 오류가 발생했습니다={}", ex.getMessage());
+
+        return ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), "데이터 처리 중 에러가 발생하였습니다.");
     }
 }

--- a/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.melodymarket.common.exception;
 
+import com.melodymarket.common.dto.ResponseDto;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
      * @return badRequest error message return
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+    public ResponseDto<Map<String, String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         BindingResult bindingResult = ex.getBindingResult();
 
         Map<String, String> errors = bindingResult.getFieldErrors().stream()
@@ -32,15 +32,12 @@ public class GlobalExceptionHandler {
                                         .ofNullable(fieldError.getDefaultMessage())
                                         .orElse(" ")));
 
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(errors);
+        return ResponseDto.of(HttpStatus.BAD_REQUEST, "유효성 검사에 실패하였습니다.", errors);
     }
 
     @ExceptionHandler(PasswordMismatchException.class)
-    public ResponseEntity<Object> handlePasswordMissMatchException(PasswordMismatchException ex) {
-        return ResponseEntity
-                .status(HttpStatus.NOT_MODIFIED)
-                .body(ex.getMessage());
+    public ResponseDto<String> handlePasswordMissMatchException(PasswordMismatchException ex) {
+
+        return ResponseDto.of(HttpStatus.NOT_MODIFIED, ex.getMessage(), null);
     }
 }

--- a/src/main/java/com/melodymarket/common/exception/PasswordSameException.java
+++ b/src/main/java/com/melodymarket/common/exception/PasswordSameException.java
@@ -1,0 +1,7 @@
+package com.melodymarket.common.exception;
+
+public class PasswordSameException extends RuntimeException {
+    public PasswordSameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/melodymarket/domain/show/entity/Show.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/Show.java
@@ -1,7 +1,7 @@
 package com.melodymarket.domain.show.entity;
 
-import com.melodymarket.domain.theater.entity.TheaterEntity;
-import com.melodymarket.domain.user.entity.UserEntity;
+import com.melodymarket.domain.theater.entity.Theater;
+import com.melodymarket.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "shows")
-public class ShowEntity {
+public class Show {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -28,14 +28,14 @@ public class ShowEntity {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
-    private UserEntity user;
+    private User user;
 
     @OneToOne
     @JoinColumn(name = "theater_id")
-    private TheaterEntity theater;
+    private Theater theater;
 
     @Builder
-    public ShowEntity(String showName, String director, String reserveStartDate, Integer price, UserEntity user, TheaterEntity theater) {
+    public Show(String showName, String director, String reserveStartDate, Integer price, User user, Theater theater) {
         this.showName = showName;
         this.director = director;
         this.reserveStartDate = reserveStartDate;

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowSchedule.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowSchedule.java
@@ -1,6 +1,6 @@
 package com.melodymarket.domain.show.entity;
 
-import com.melodymarket.domain.theater.entity.TheaterReserveEntity;
+import com.melodymarket.domain.theater.entity.TheaterReserve;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,25 +11,25 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "show_schedule")
-public class ShowScheduleEntity {
+public class ShowSchedule {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     @JoinColumn(name = "show_id")
-    private ShowEntity showList;
+    private Show showList;
     @Column
     private String showDate;
 
     @OneToOne
     @JoinColumn(name = "theater_reserve_id")
-    private TheaterReserveEntity theaterReserve;
+    private TheaterReserve theaterReserve;
     @ManyToOne
     @JoinColumn(name = "show_seat_id")
-    private ShowSeatEntity showSeat;
+    private ShowSeat showSeat;
 
     @Builder
-    public ShowScheduleEntity(ShowEntity showList, String showDate, TheaterReserveEntity theaterReserve, ShowSeatEntity showSeat) {
+    public ShowSchedule(Show showList, String showDate, TheaterReserve theaterReserve, ShowSeat showSeat) {
         this.showList = showList;
         this.showDate = showDate;
         this.theaterReserve = theaterReserve;

--- a/src/main/java/com/melodymarket/domain/show/entity/ShowSeat.java
+++ b/src/main/java/com/melodymarket/domain/show/entity/ShowSeat.java
@@ -9,17 +9,17 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "show_seat")
-public class ShowSeatEntity {
+public class ShowSeat {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToMany(mappedBy = "showSeat")
-    private List<ShowScheduleEntity> showSchedule;
+    private List<ShowSchedule> showSchedule;
     @Column
     private Long seatId;
 
     @Builder
-    public ShowSeatEntity(List<ShowScheduleEntity> showSchedule, Long seatId) {
+    public ShowSeat(List<ShowSchedule> showSchedule, Long seatId) {
         this.showSchedule = showSchedule;
         this.seatId = seatId;
     }

--- a/src/main/java/com/melodymarket/domain/theater/entity/Theater.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/Theater.java
@@ -1,7 +1,7 @@
 package com.melodymarket.domain.theater.entity;
 
 import com.melodymarket.application.theater.dto.TheaterDto;
-import com.melodymarket.domain.show.entity.ShowEntity;
+import com.melodymarket.domain.show.entity.Show;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "theater")
-public class TheaterEntity {
+public class Theater {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -23,23 +23,23 @@ public class TheaterEntity {
     @Column
     private String location;
     @OneToOne(mappedBy = "theater")
-    private ShowEntity showList;
+    private Show showList;
     @OneToMany(mappedBy = "theater", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<TheaterRoomEntity> rooms;
+    private List<TheaterRoom> rooms;
 
     @Builder
-    public TheaterEntity(String name, String location, ShowEntity showList, List<TheaterRoomEntity> rooms) {
+    public Theater(String name, String location, Show showList, List<TheaterRoom> rooms) {
         this.name = name;
         this.location = location;
         this.showList = showList;
         this.rooms = rooms;
     }
 
-    public static TheaterEntity from(TheaterDto theaterDto) {
-        return TheaterEntity.builder()
+    public static Theater from(TheaterDto theaterDto) {
+        return Theater.builder()
                 .name(theaterDto.getName())
                 .location(theaterDto.getLocation())
-                .rooms(TheaterRoomEntity.from(theaterDto.getRoomsInfo()))
+                .rooms(TheaterRoom.from(theaterDto.getRoomsInfo()))
                 .build();
     }
 

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserve.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterReserve.java
@@ -1,6 +1,6 @@
 package com.melodymarket.domain.theater.entity;
 
-import com.melodymarket.domain.show.entity.ShowScheduleEntity;
+import com.melodymarket.domain.show.entity.ShowSchedule;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,17 +11,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "theater_reserve")
-public class TheaterReserveEntity {
+public class TheaterReserve {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne(mappedBy = "theaterReserve", cascade = CascadeType.ALL)
-    private ShowScheduleEntity showSchedule;
+    private ShowSchedule showSchedule;
     @Column
     private String reserveDate;
 
     @Builder
-    public TheaterReserveEntity(ShowScheduleEntity showSchedule, String reserveDate) {
+    public TheaterReserve(ShowSchedule showSchedule, String reserveDate) {
         this.showSchedule = showSchedule;
         this.reserveDate = reserveDate;
     }

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoom.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterRoom.java
@@ -13,35 +13,35 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "theater_room")
-public class TheaterRoomEntity {
+public class TheaterRoom {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     @JoinColumn(name = "theater_id")
-    private TheaterEntity theater;
+    private Theater theater;
     @Column
     private String name;
 
     @OneToMany(mappedBy = "theaterRoom", cascade = CascadeType.ALL)
-    private List<TheaterSeatEntity> seats;
+    private List<TheaterSeat> seats;
 
-    protected void setTheater(TheaterEntity theater) {
+    protected void setTheater(Theater theater) {
         this.theater = theater;
     }
 
     @Builder
-    public TheaterRoomEntity(TheaterEntity theater, String name, List<TheaterSeatEntity> seats) {
+    public TheaterRoom(Theater theater, String name, List<TheaterSeat> seats) {
         this.theater = theater;
         this.name = name;
         this.seats = seats;
     }
 
-    public static List<TheaterRoomEntity> from(List<TheaterRoomDto> theaterRoomDto) {
+    public static List<TheaterRoom> from(List<TheaterRoomDto> theaterRoomDto) {
         return theaterRoomDto.stream()
-                .map(roomDto -> TheaterRoomEntity.builder()
+                .map(roomDto -> TheaterRoom.builder()
                         .name(roomDto.getRoomName())
-                        .seats(TheaterSeatEntity.from(roomDto.getSeatData()))
+                        .seats(TheaterSeat.from(roomDto.getSeatData()))
                         .build())
                 .toList();
     }

--- a/src/main/java/com/melodymarket/domain/theater/entity/TheaterSeat.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/TheaterSeat.java
@@ -14,13 +14,13 @@ import java.util.stream.Collectors;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "seat")
-public class TheaterSeatEntity {
+public class TheaterSeat {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     @JoinColumn(name = "theater_room_id")
-    private TheaterRoomEntity theaterRoom;
+    private TheaterRoom theaterRoom;
     @Column
     private Integer seatFloor;
     @Column
@@ -28,21 +28,21 @@ public class TheaterSeatEntity {
     @Column
     private Integer seatNumber;
 
-    protected void setTheaterRoom(TheaterRoomEntity theaterRoom) {
+    protected void setTheaterRoom(TheaterRoom theaterRoom) {
         this.theaterRoom = theaterRoom;
     }
 
     @Builder
-    public TheaterSeatEntity(TheaterRoomEntity theaterRoom, Integer seatFloor, Integer seatRow, Integer seatNumber) {
+    public TheaterSeat(TheaterRoom theaterRoom, Integer seatFloor, Integer seatRow, Integer seatNumber) {
         this.theaterRoom = theaterRoom;
         this.seatFloor = seatFloor;
         this.seatRow = seatRow;
         this.seatNumber = seatNumber;
     }
 
-    public static List<TheaterSeatEntity> from(List<TheaterSeatDto> seatDtos) {
+    public static List<TheaterSeat> from(List<TheaterSeatDto> seatDtos) {
         return seatDtos.stream()
-                .map(seatDto -> TheaterSeatEntity.builder()
+                .map(seatDto -> TheaterSeat.builder()
                         .seatFloor(seatDto.getSeatFloor())
                         .seatRow(seatDto.getSeatRow())
                         .seatNumber(seatDto.getSeatNumber())

--- a/src/main/java/com/melodymarket/domain/user/entity/User.java
+++ b/src/main/java/com/melodymarket/domain/user/entity/User.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "melody_user")
-public class UserEntity {
+public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -43,7 +43,7 @@ public class UserEntity {
     private Integer membershipLevel;
 
     @Builder
-    public UserEntity(String loginId, String username, String userPassword, String nickname, String email, String birthDate, String joinDate, Integer membershipLevel) {
+    public User(String loginId, String username, String userPassword, String nickname, String email, String birthDate, String joinDate, Integer membershipLevel) {
         this.loginId = loginId;
         this.username = username;
         this.userPassword = userPassword;
@@ -65,8 +65,8 @@ public class UserEntity {
         this.userPassword = cryptPasswordService.encryptPassword(newPassword);
     }
 
-    public static UserEntity from(UserDto userDto, String encryptPassword) {
-        return UserEntity
+    public static User from(UserDto userDto, String encryptPassword) {
+        return User
                 .builder()
                 .loginId(userDto.getLoginId())
                 .userPassword(encryptPassword)
@@ -79,7 +79,7 @@ public class UserEntity {
                 .build();
     }
 
-    public UserEntity modifyValueSetUserEntity(UpdateUserDto updateUserDto) {
+    public User modifyValueSetUserEntity(UpdateUserDto updateUserDto) {
         if (updateUserDto.getNickname() != null) {
             this.nickname = updateUserDto.getNickname();
         }

--- a/src/main/java/com/melodymarket/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/melodymarket/domain/user/entity/UserEntity.java
@@ -2,21 +2,22 @@ package com.melodymarket.domain.user.entity;
 
 import com.melodymarket.application.user.dto.UpdateUserDto;
 import com.melodymarket.application.user.dto.UserDto;
+import com.melodymarket.application.user.service.CryptPasswordService;
 import com.melodymarket.domain.user.enums.MembershipLevelEnum;
 import com.melodymarket.util.DateFormattingUtil;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
 @Getter
-@Setter
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "melody_user")
 public class UserEntity {
     @Id
@@ -41,11 +42,27 @@ public class UserEntity {
     @Column
     private Integer membershipLevel;
 
+    @Builder
+    public UserEntity(String loginId, String username, String userPassword, String nickname, String email, String birthDate, String joinDate, Integer membershipLevel) {
+        this.loginId = loginId;
+        this.username = username;
+        this.userPassword = userPassword;
+        this.nickname = nickname;
+        this.email = email;
+        this.birthDate = birthDate;
+        this.joinDate = joinDate;
+        this.membershipLevel = membershipLevel;
+    }
+
     @PrePersist
     private void prePersist() {
         if (this.membershipLevel == null) {
             this.membershipLevel = MembershipLevelEnum.BRONZE.getLevel();
         }
+    }
+
+    public void changePassword(String newPassword, CryptPasswordService cryptPasswordService) {
+        this.userPassword = cryptPasswordService.encryptPassword(newPassword);
     }
 
     public static UserEntity from(UserDto userDto, String encryptPassword) {
@@ -64,10 +81,10 @@ public class UserEntity {
 
     public UserEntity modifyValueSetUserEntity(UpdateUserDto updateUserDto) {
         if (updateUserDto.getNickname() != null) {
-            this.setNickname(updateUserDto.getNickname());
+            this.nickname = updateUserDto.getNickname();
         }
         if (updateUserDto.getEmail() != null) {
-            this.setEmail(updateUserDto.getEmail());
+            this.email = updateUserDto.getEmail();
         }
         return this;
     }

--- a/src/main/java/com/melodymarket/infrastructure/exception/DataAccessCustomException.java
+++ b/src/main/java/com/melodymarket/infrastructure/exception/DataAccessCustomException.java
@@ -1,9 +1,0 @@
-package com.melodymarket.infrastructure.exception;
-
-import org.springframework.dao.DataAccessException;
-
-public class DataAccessCustomException extends DataAccessException {
-    public DataAccessCustomException(String msg) {
-        super(msg);
-    }
-}

--- a/src/main/java/com/melodymarket/infrastructure/exception/DatabaseExceptionHandler.java
+++ b/src/main/java/com/melodymarket/infrastructure/exception/DatabaseExceptionHandler.java
@@ -1,31 +1,30 @@
 package com.melodymarket.infrastructure.exception;
 
 import com.melodymarket.common.dto.ResponseDto;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class DatabaseExceptionHandler {
     @ExceptionHandler(DataDuplicateKeyException.class)
-    public ResponseEntity<Object> handleDuplicateKeyException(DataDuplicateKeyException ex) {
-        return ResponseEntity
-                .status(HttpStatus.CONFLICT)
-                .body(ex.getMessage());
+    public ResponseDto<Object> handleDuplicateKeyException(DataDuplicateKeyException ex) {
+        return ResponseDto.of(HttpStatus.CONFLICT,
+                ex.getMessage(),
+                "");
 
     }
 
     @ExceptionHandler(DataNotFoundException.class)
-    public ResponseEntity<Object> handleNotFoundException(DataNotFoundException ex) {
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ex.getMessage());
-
+    public ResponseDto<Object> handleNotFoundException(DataNotFoundException ex) {
+        return ResponseDto.of(HttpStatus.NOT_FOUND,
+                ex.getMessage(),
+                "");
     }
 
-    @ExceptionHandler(DataAccessCustomException.class)
-    public ResponseDto<Object> handleDataAccessException(DataAccessCustomException ex) {
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseDto<Object> handleDataAccessException(DataAccessException ex) {
         return ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR,
                 ex.getMessage(),
                 "");

--- a/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
+++ b/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
@@ -1,11 +1,11 @@
 package com.melodymarket.infrastructure.jpa.theater.repository;
 
-import com.melodymarket.domain.theater.entity.TheaterEntity;
+import com.melodymarket.domain.theater.entity.Theater;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TheaterRepository extends JpaRepository<TheaterEntity, Long> {
+public interface TheaterRepository extends JpaRepository<Theater, Long> {
     @Override
-    <S extends TheaterEntity> S save(S theaterEntity);
+    <S extends Theater> S save(S theaterEntity);
 
     boolean existsByName(String name);
 }

--- a/src/main/java/com/melodymarket/infrastructure/jpa/user/repository/UserRepository.java
+++ b/src/main/java/com/melodymarket/infrastructure/jpa/user/repository/UserRepository.java
@@ -1,22 +1,22 @@
 package com.melodymarket.infrastructure.jpa.user.repository;
 
-import com.melodymarket.domain.user.entity.UserEntity;
+import com.melodymarket.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<UserEntity, Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByLoginId(String loginId);
 
     boolean existsByNickname(String nickname);
 
     @Override
-    <S extends UserEntity> S save(S userEntity);
+    <S extends User> S save(S userEntity);
 
     @Override
-    Optional<UserEntity> findById(Long id);
+    Optional<User> findById(Long id);
 
-    Optional<UserEntity> findByLoginId(String loginId);
+    Optional<User> findByLoginId(String loginId);
 
     @Override
     void deleteById(Long id);

--- a/src/main/java/com/melodymarket/infrastructure/security/MelodyUserDetails.java
+++ b/src/main/java/com/melodymarket/infrastructure/security/MelodyUserDetails.java
@@ -1,6 +1,6 @@
 package com.melodymarket.infrastructure.security;
 
-import com.melodymarket.domain.user.entity.UserEntity;
+import com.melodymarket.domain.user.entity.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -17,7 +17,7 @@ public class MelodyUserDetails implements UserDetails {
     private Collection<? extends GrantedAuthority> authorities;
 
 
-    public MelodyUserDetails(UserEntity user) {
+    public MelodyUserDetails(User user) {
         this.username = user.getUsername();
         this.id = user.getId();
         this.loginId = user.getLoginId();

--- a/src/main/java/com/melodymarket/presentation/admin/controller/JoinUserController.java
+++ b/src/main/java/com/melodymarket/presentation/admin/controller/JoinUserController.java
@@ -3,12 +3,13 @@ package com.melodymarket.presentation.admin.controller;
 import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.application.user.service.UserJoinService;
 import com.melodymarket.application.user.service.UserJoinServiceImpl;
+import com.melodymarket.common.dto.ResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,11 +34,12 @@ public class JoinUserController {
      * @return User exists or User not exists
      */
     @GetMapping("/check-login-id")
-    public ResponseEntity<String> isUserIdAvailable(@RequestParam("login-id") String loginId,
-                                                    HttpServletRequest request) {
+    public ResponseDto<String> isUserIdAvailable(@RequestParam("login-id") String loginId,
+                                                 HttpServletRequest request) {
         log.debug("[isUserIdAvailable] [Session_id={}] loginId={}", request.getSession(false).getId(), loginId);
         userJoinService.checkUserIdDuplication(loginId, request.getSession(false).getId());
-        return ResponseEntity.ok("사용 가능한 아이디 입니다.");
+
+        return ResponseDto.of(HttpStatus.OK, "사용 가능한 아이디 입니다.", null);
     }
 
     /**
@@ -47,11 +49,12 @@ public class JoinUserController {
      * @return User exists or User not exists
      */
     @GetMapping("/check-nickname")
-    public ResponseEntity<String> isNicknameAvailable(@RequestParam("nickname") String nickname,
-                                                      HttpServletRequest request) {
+    public ResponseDto<String> isNicknameAvailable(@RequestParam("nickname") String nickname,
+                                                   HttpServletRequest request) {
         log.debug("[isNicknameAvailable] [Session_id={}] nickname={}", request.getSession(false).getId(), nickname);
         userJoinService.checkNicknameDuplication(nickname, request.getSession(false).getId());
-        return ResponseEntity.ok("사용 가능한 닉네임 입니다.");
+
+        return ResponseDto.of(HttpStatus.OK, "사용 가능한 닉네임 입니다.", null);
     }
 
     /**
@@ -61,11 +64,12 @@ public class JoinUserController {
      * @return User exists or User not exists
      */
     @PostMapping("/save")
-    public ResponseEntity<Object> createUser(@RequestBody @Validated UserDto userDto,
-                                             HttpServletRequest request) {
-        log.debug("[CreateUser] [Session_id={}] user info={}", request.getSession(false).getId(),userDto.toString());
+    public ResponseDto<String> createUser(@RequestBody @Validated UserDto userDto,
+                                          HttpServletRequest request) {
+        log.debug("[CreateUser] [Session_id={}] user info={}", request.getSession(false).getId(), userDto.toString());
         userJoinService.signUpUser(userDto, request.getSession(false).getId());
-        return ResponseEntity.ok("유저 생성에 성공했습니다.");
+
+        return ResponseDto.of(HttpStatus.OK, "유저 생성에 성공했습니다.", null);
     }
 
 }

--- a/src/main/java/com/melodymarket/presentation/admin/controller/ManageUserController.java
+++ b/src/main/java/com/melodymarket/presentation/admin/controller/ManageUserController.java
@@ -4,17 +4,18 @@ import com.melodymarket.application.user.dto.UpdatePasswordDto;
 import com.melodymarket.application.user.dto.UpdateUserDto;
 import com.melodymarket.application.user.service.UserInfoManageService;
 import com.melodymarket.application.user.service.UserInfoManageServiceImpl;
+import com.melodymarket.common.dto.ResponseDto;
+import com.melodymarket.presentation.admin.dto.UserResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
-@Controller
+@RestController
 @RequestMapping("/v1/user")
 public class ManageUserController {
 
@@ -26,31 +27,35 @@ public class ManageUserController {
     }
 
     @GetMapping("/details/{user-id}")
-    public ResponseEntity<Object> getUserInfo(@PathVariable("user-id") Long id) {
+    public ResponseDto<UserResponseDto> getUserInfo(@PathVariable("user-id") Long id) {
         log.debug("[getUserInfo] request user id={}", id);
-        return ResponseEntity.ok(userInfoManageService.getUserDetails(id));
+
+        return ResponseDto.of(HttpStatus.OK, "유저 정보 조회에 성공했습니다.",
+                userInfoManageService.getUserDetails(id));
     }
 
     @PostMapping("/details/{user-id}/update-password")
-    public ResponseEntity<Object> modifyUserPassword(@PathVariable("user-id") Long id,
-                                                     @Validated @RequestBody UpdatePasswordDto updatePasswordDto) {
+    public ResponseDto<String> modifyUserPassword(@PathVariable("user-id") Long id,
+                                                  @Validated @RequestBody UpdatePasswordDto updatePasswordDto) {
         log.debug("[modifyUserPassword] request user id={}", id);
         userInfoManageService.modifyUserPassword(id, updatePasswordDto);
-        return ResponseEntity.ok("비밀번호가 변경되었습니다.");
+
+        return ResponseDto.of(HttpStatus.OK, "비밀번호가 변경되었습니다.", null);
     }
 
     @PostMapping("/details/{user-id}/update-user-info")
-    public ResponseEntity<Object> modifyUserInfo(@PathVariable("user-id") Long id,
-                                                 @Validated @RequestBody UpdateUserDto updateUserDto) {
+    public ResponseDto<String> modifyUserInfo(@PathVariable("user-id") Long id,
+                                              @Validated @RequestBody UpdateUserDto updateUserDto) {
         log.debug("[modifyUserInfo] request user id={}", id);
         userInfoManageService.modifyUserDetails(id, updateUserDto);
-        return ResponseEntity.ok("변경이 완료되었습니다.");
+
+        return ResponseDto.of(HttpStatus.OK, "변경이 완료되었습니다.", null);
     }
 
     @PostMapping("/delete/{user-id}")
-    public ResponseEntity<Object> deleteUsert(@PathVariable("user-id") Long id,
-                                              @RequestBody String password,
-                                              HttpServletRequest request) {
+    public ResponseDto<String> deleteUsert(@PathVariable("user-id") Long id,
+                                           @RequestBody String password,
+                                           HttpServletRequest request) {
         log.debug("[deleteUser] request user id={}", id);
         userInfoManageService.deleteUser(id, password);
 
@@ -58,7 +63,8 @@ public class ManageUserController {
         if (session != null) {
             session.invalidate();
         }
-        return ResponseEntity.ok("회원 탈퇴에 성공했습니다.");
+
+        return ResponseDto.of(HttpStatus.OK, "회원 탈퇴에 성공했습니다.", null);
     }
 
 

--- a/src/main/java/com/melodymarket/presentation/admin/dto/UserResponseDto.java
+++ b/src/main/java/com/melodymarket/presentation/admin/dto/UserResponseDto.java
@@ -1,0 +1,30 @@
+package com.melodymarket.presentation.admin.dto;
+
+import com.melodymarket.domain.user.entity.UserEntity;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponseDto {
+    private String loginId;
+    private String username;
+    private String nickname;
+    private String email;
+    private String birthDate;
+    private Integer membershipLevel;
+
+    public static UserResponseDto from(UserEntity userEntity) {
+        return UserResponseDto
+                .builder()
+                .loginId(userEntity.getLoginId())
+                .username(userEntity.getUsername())
+                .nickname(userEntity.getNickname())
+                .birthDate(userEntity.getBirthDate())
+                .email(userEntity.getEmail())
+                .membershipLevel(userEntity.getMembershipLevel())
+                .build();
+    }
+}

--- a/src/main/java/com/melodymarket/presentation/admin/dto/UserResponseDto.java
+++ b/src/main/java/com/melodymarket/presentation/admin/dto/UserResponseDto.java
@@ -1,6 +1,6 @@
 package com.melodymarket.presentation.admin.dto;
 
-import com.melodymarket.domain.user.entity.UserEntity;
+import com.melodymarket.domain.user.entity.User;
 import lombok.*;
 
 @Getter
@@ -16,15 +16,15 @@ public class UserResponseDto {
     private String birthDate;
     private Integer membershipLevel;
 
-    public static UserResponseDto from(UserEntity userEntity) {
+    public static UserResponseDto from(User user) {
         return UserResponseDto
                 .builder()
-                .loginId(userEntity.getLoginId())
-                .username(userEntity.getUsername())
-                .nickname(userEntity.getNickname())
-                .birthDate(userEntity.getBirthDate())
-                .email(userEntity.getEmail())
-                .membershipLevel(userEntity.getMembershipLevel())
+                .loginId(user.getLoginId())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .birthDate(user.getBirthDate())
+                .email(user.getEmail())
+                .membershipLevel(user.getMembershipLevel())
                 .build();
     }
 }

--- a/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
+++ b/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
@@ -7,7 +7,6 @@ import com.melodymarket.common.dto.ResponseDto;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,10 +25,10 @@ public class ManageTheaterController {
     }
 
     @PostMapping("/add")
-    public ResponseEntity<ResponseDto<TheaterResponseDto>> addTheater(@RequestBody @Validated TheaterDto theaterDto) {
+    public ResponseDto<TheaterResponseDto> addTheater(@RequestBody @Validated TheaterDto theaterDto) {
 
-        return new ResponseEntity<>(ResponseDto.of(HttpStatus.OK,
+        return ResponseDto.of(HttpStatus.OK,
                 "공연장 등록이 완료되었습니다.",
-                manageTheaterService.saveTheater(theaterDto)), HttpStatus.OK);
+                manageTheaterService.saveTheater(theaterDto));
     }
 }

--- a/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
@@ -3,7 +3,7 @@ package com.melodymarket.application.theater.service;
 import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.application.theater.dto.TheaterRoomDto;
 import com.melodymarket.application.theater.dto.TheaterSeatDto;
-import com.melodymarket.infrastructure.exception.DataAccessCustomException;
+import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
 import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -53,7 +53,7 @@ class TheaterManageServiceImplTest {
         Exception exception = assertThrows(Exception.class, () -> manageTheaterService.saveTheater(theaterTestDto));
 
         //then
-        assertTrue(exception instanceof DataAccessCustomException);
+        assertTrue(exception instanceof DataDuplicateKeyException);
     }
 
     private TheaterDto createTestTheater(String name) {

--- a/src/test/java/com/melodymarket/application/user/service/UserInfoManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/user/service/UserInfoManageServiceImplTest.java
@@ -4,9 +4,11 @@ import com.melodymarket.application.user.dto.UpdatePasswordDto;
 import com.melodymarket.application.user.dto.UpdateUserDto;
 import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.common.exception.PasswordMismatchException;
+import com.melodymarket.common.exception.PasswordSameException;
 import com.melodymarket.domain.user.entity.UserEntity;
 import com.melodymarket.infrastructure.exception.DataNotFoundException;
 import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
+import com.melodymarket.presentation.admin.dto.UserResponseDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,12 +34,12 @@ class UserInfoManageServiceImplTest {
     UserRepository userRepository;
     UserDto userDto;
     UserEntity userSelect;
-    String sessionId="testSessionId";
+    String sessionId = "testSessionId";
 
     @BeforeEach
     void insert() {
         this.userDto = createTestUser();
-        userJoinServiceImpl.signUpUser(userDto,sessionId);
+        userJoinServiceImpl.signUpUser(userDto, sessionId);
         this.userSelect = userRepository.findByLoginId("testuser").orElse(null);
     }
 
@@ -48,7 +50,7 @@ class UserInfoManageServiceImplTest {
         Long id = this.userSelect.getId();
 
         //when
-        UserDto returnUser = userInfoManageService.getUserDetails(id);
+        UserResponseDto returnUser = userInfoManageService.getUserDetails(id);
 
         //then
         Assertions.assertThat(returnUser).isNotNull();
@@ -77,11 +79,11 @@ class UserInfoManageServiceImplTest {
 
         //when
         userInfoManageService.modifyUserPassword(id, updatePasswordDto);
-        UserDto userDto = userInfoManageService.getUserDetails(id);
 
         //then
-        Assertions.assertThat(cryptPasswordService
-                        .isPasswordMatch(updatePasswordDto.getNewPassword(), userDto.getUserPassword())).isTrue();
+        updatePasswordDto.setOldPassword(updatePasswordDto.getNewPassword());
+        Exception exception = assertThrows(Exception.class, () -> userInfoManageService.modifyUserPassword(id, updatePasswordDto));
+        assertTrue(exception instanceof PasswordSameException);
     }
 
     @Test
@@ -93,7 +95,7 @@ class UserInfoManageServiceImplTest {
         updatePasswordDto.setOldPassword("incorrect");
 
         //when
-         Exception exception =
+        Exception exception =
                 assertThrows(Exception.class, () -> userInfoManageService.modifyUserPassword(id, updatePasswordDto));
 
         //then
@@ -124,7 +126,7 @@ class UserInfoManageServiceImplTest {
 
         //when
         userInfoManageService.modifyUserDetails(id, updateUserDto);
-        UserDto userDto = userInfoManageService.getUserDetails(id);
+        UserResponseDto userDto = userInfoManageService.getUserDetails(id);
 
         //then
         Assertions.assertThat(userDto.getNickname()).isEqualTo(updateUserDto.getNickname());
@@ -139,7 +141,7 @@ class UserInfoManageServiceImplTest {
 
         //when
         userInfoManageService.modifyUserDetails(id, updateUserDto);
-        UserDto userDto = userInfoManageService.getUserDetails(id);
+        UserResponseDto userDto = userInfoManageService.getUserDetails(id);
 
         //then
         Assertions.assertThat(userDto.getEmail()).isEqualTo(updateUserDto.getEmail());
@@ -154,7 +156,7 @@ class UserInfoManageServiceImplTest {
 
         //when
         userInfoManageService.modifyUserDetails(id, updateUserDto);
-        UserDto userDto = userInfoManageService.getUserDetails(id);
+        UserResponseDto userDto = userInfoManageService.getUserDetails(id);
 
         //then
         org.junit.jupiter.api.Assertions.assertAll(

--- a/src/test/java/com/melodymarket/application/user/service/UserInfoManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/user/service/UserInfoManageServiceImplTest.java
@@ -5,7 +5,7 @@ import com.melodymarket.application.user.dto.UpdateUserDto;
 import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.common.exception.PasswordMismatchException;
 import com.melodymarket.common.exception.PasswordSameException;
-import com.melodymarket.domain.user.entity.UserEntity;
+import com.melodymarket.domain.user.entity.User;
 import com.melodymarket.infrastructure.exception.DataNotFoundException;
 import com.melodymarket.infrastructure.jpa.user.repository.UserRepository;
 import com.melodymarket.presentation.admin.dto.UserResponseDto;
@@ -33,7 +33,7 @@ class UserInfoManageServiceImplTest {
     @Autowired
     UserRepository userRepository;
     UserDto userDto;
-    UserEntity userSelect;
+    User userSelect;
     String sessionId = "testSessionId";
 
     @BeforeEach

--- a/src/test/java/com/melodymarket/presentation/admin/controller/JoinUserControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/admin/controller/JoinUserControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -19,7 +20,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("회원가입 중복 검사 테스트")
@@ -52,23 +52,27 @@ class JoinUserControllerTest {
     @Test
     @DisplayName("[GET] 유저아이디 중복 검사 API")
     void isUserIdNotAvailable() throws Exception {
+        //given
+        String testUser = "testuser";
+
         // when
-        mockMvc.perform(get("/v1/user/join/check-login-id?login-id=testuser"))
+        ResultActions resultActions = mockMvc.perform(get("/v1/user/join/check-login-id?login-id=" + testUser));
 
         // then
-                .andExpect(status().isOk())
-                .andExpect(content().string("사용 가능한 아이디 입니다."));
+        resultActions.andExpect(status().isOk());
     }
 
     @Test
     @DisplayName("[GET] 닉네임 중복 검사 API 테스트")
     void isNicknameAvailable() throws Exception {
+        //given
+        String testNickname = "testnickname";
 
         //when
-        mockMvc.perform(get("/v1/user/join/check-nickname?nickname=testnickname"))
+        ResultActions resultActions = mockMvc.perform(get("/v1/user/join/check-nickname?nickname=" + testNickname));
+
         //then
-                .andExpect(status().isOk())
-                .andExpect(content().string("사용 가능한 닉네임 입니다."));
+        resultActions.andExpect(status().isOk());
     }
 
     @Test
@@ -80,13 +84,14 @@ class JoinUserControllerTest {
         //json 형식으로 convert
         ObjectMapper objectMapper = new ObjectMapper();
         String jsonTestUser = objectMapper.writeValueAsString(testUser);
+
         //when
-        mockMvc.perform(post("/v1/user/join/save")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(jsonTestUser))
+        ResultActions resultActions = mockMvc.perform(post("/v1/user/join/save")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonTestUser));
+
         //then
-                .andExpect(status().isOk())
-                .andExpect(content().string("유저 생성에 성공했습니다."));
+        resultActions.andExpect(status().isOk());
     }
 
     public UserDto createTestUser() {

--- a/src/test/java/com/melodymarket/presentation/admin/controller/ManageUserControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/admin/controller/ManageUserControllerTest.java
@@ -5,6 +5,7 @@ import com.melodymarket.application.user.dto.UpdatePasswordDto;
 import com.melodymarket.application.user.dto.UpdateUserDto;
 import com.melodymarket.application.user.dto.UserDto;
 import com.melodymarket.application.user.service.UserInfoManageServiceImpl;
+import com.melodymarket.presentation.admin.dto.UserResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,9 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("회원조희 API 테스트")
 @WithMockUser(roles = "USER")
@@ -61,17 +64,22 @@ class ManageUserControllerTest {
         Long id = 1L;
 
         //when
-        Mockito.when(userInfoManageService.getUserDetails(id)).thenReturn(userDto);
+        Mockito.when(userInfoManageService.getUserDetails(id))
+                .thenReturn(UserResponseDto.builder()
+                        .username(userDto.getUsername())
+                        .nickname(userDto.getNickname())
+                        .birthDate(userDto.getBirthDate())
+                        .email(userDto.getEmail()).build());
         ResultActions resultActions = mockMvc.perform(get("/v1/user/details/" + id));
 
         //then
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.loginId").value("testuser"))
-                .andExpect(jsonPath("$.username").value("테스트"))
-                .andExpect(jsonPath("$.nickname").value("imtest"))
-                .andExpect(jsonPath("$.birthDate").value("19970908"))
-                .andExpect(jsonPath("$.email").value("test@example.com"));
-
+        resultActions.andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("OK"))
+                .andExpect(jsonPath("$.message").value("유저 정보 조회에 성공했습니다."))
+                .andExpect(jsonPath("$.data.username").value("테스트"))
+                .andExpect(jsonPath("$.data.nickname").value("imtest"))
+                .andExpect(jsonPath("$.data.birthDate").value("19970908"))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"));
     }
 
     @Test
@@ -89,8 +97,7 @@ class ManageUserControllerTest {
                 .content(jsonTestDto));
 
         //then
-        resultActions.andExpect(status().isOk())
-                .andExpect(content().string("비밀번호가 변경되었습니다."));
+        resultActions.andExpect(status().isOk());
     }
 
     @Test
@@ -122,13 +129,12 @@ class ManageUserControllerTest {
         String requestBody = objectMapper.writeValueAsString(password);
 
         //when
-        ResultActions resultActions = mockMvc.perform(post("/v1/user/delete/" + id )
+        ResultActions resultActions = mockMvc.perform(post("/v1/user/delete/" + id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody));
 
         //then
-        resultActions.andExpect(status().isOk())
-                .andExpect(content().string("회원 탈퇴에 성공했습니다."));
+        resultActions.andExpect(status().isOk());
     }
 
 

--- a/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -59,11 +60,11 @@ class ManageTheaterControllerTest {
         String json = objectMapper.writeValueAsString(testTheater);
 
         //when
-        mockMvc.perform(post("/v1/theater/add")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(json))
-                //then
-                .andExpect(status().isOk());
+        ResultActions resultActions = mockMvc.perform(post("/v1/theater/add")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json));
+        //then
+        resultActions.andExpect(status().isOk());
     }
 
     private TheaterDto createTestTheater() {


### PR DESCRIPTION
* String으로 응답하는 것이 아닌, 표준화 된 응답 Dto를 만들어 일관성 있는 구조의 응답을 만들도록 수정
* 응답 변경에 따른 테스트 코드 수정
* RequestDto로 응답하지 않는 코드와 분리하기 위해 만들었던 임시 DataAccessCustomException.java 삭제
* Entity 객체에 무분별한 접근이 일어날 수 있는 어노테이션 제거
* UserResponseDto를 추가하여 민감정보는 응답에 포함하지 않고, 응답으로 보낼 데이터를 선택하여 포함할 수 있도록 분리
* 기존 Request로 받은 Dto를 통해 응답하는 부분을 수정하고, 응답 dto에 변환 로직 이관
* 동일한 패스워드로 변경에 대한 예외 추가 -> 예외처리의 추가 효과와, UserResponseDto에 password를 포함하지 않으므로 테스트에도 추가 사용

close #43