### PR TITLE
CHORE:  공연장 등록 API userId도 같이 저장하도록 추가

### DIFF
--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
@@ -4,8 +4,6 @@ import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 
 public interface ManageTheaterService {
-    TheaterResponseDto saveTheater(TheaterDto theaterDto);
-
-    boolean findByTheaterName(String theaterName);
+    TheaterResponseDto saveTheater(TheaterDto theaterDto, Long userId);
 
 }

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -21,19 +21,14 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
     TheaterRepository theaterRepository;
 
     @Override
-    public TheaterResponseDto saveTheater(TheaterDto theaterDto) {
-        if (findByTheaterName(theaterDto.getName())) {
+    public TheaterResponseDto saveTheater(TheaterDto theaterDto, Long userId) {
+        if (theaterRepository.existsByName(theaterDto.getName())) {
             throw new DataDuplicateKeyException("이미 등록 된 공연장 이름입니다.");
         }
-        Theater theater = Theater.from(theaterDto);
+        Theater theater = Theater.from(theaterDto, userId);
         setTheaterPersistence(theater);
         theaterRepository.save(theater);
         return TheaterResponseDto.from(theaterDto);
-    }
-
-    @Override
-    public boolean findByTheaterName(String theaterName) {
-        return theaterRepository.existsByName(theaterName);
     }
 
     private void setTheaterPersistence(Theater theater) {

--- a/src/main/java/com/melodymarket/domain/theater/entity/Theater.java
+++ b/src/main/java/com/melodymarket/domain/theater/entity/Theater.java
@@ -19,6 +19,8 @@ public class Theater {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column
+    private Long userId;
+    @Column
     private String name;
     @Column
     private String location;
@@ -28,16 +30,18 @@ public class Theater {
     private List<TheaterRoom> rooms;
 
     @Builder
-    public Theater(String name, String location, Show showList, List<TheaterRoom> rooms) {
+    public Theater(String name, String location, Show showList, List<TheaterRoom> rooms, Long userId) {
         this.name = name;
         this.location = location;
         this.showList = showList;
         this.rooms = rooms;
+        this.userId = userId;
     }
 
-    public static Theater from(TheaterDto theaterDto) {
+    public static Theater from(TheaterDto theaterDto, Long userId) {
         return Theater.builder()
                 .name(theaterDto.getName())
+                .userId(userId)
                 .location(theaterDto.getLocation())
                 .rooms(TheaterRoom.from(theaterDto.getRoomsInfo()))
                 .build();

--- a/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
+++ b/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
@@ -4,9 +4,11 @@ import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.application.theater.service.ManageTheaterService;
 import com.melodymarket.application.theater.service.ManageTheaterServiceImpl;
 import com.melodymarket.common.dto.ResponseDto;
+import com.melodymarket.infrastructure.security.MelodyUserDetails;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,10 +27,11 @@ public class ManageTheaterController {
     }
 
     @PostMapping("/add")
-    public ResponseDto<TheaterResponseDto> addTheater(@RequestBody @Validated TheaterDto theaterDto) {
+    public ResponseDto<TheaterResponseDto> addTheater(@RequestBody @Validated TheaterDto theaterDto,
+                                                      @AuthenticationPrincipal MelodyUserDetails melodyUserDetails) {
 
         return ResponseDto.of(HttpStatus.OK,
                 "공연장 등록이 완료되었습니다.",
-                manageTheaterService.saveTheater(theaterDto));
+                manageTheaterService.saveTheater(theaterDto, melodyUserDetails.getId()));
     }
 }

--- a/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
@@ -30,7 +30,8 @@ class TheaterManageServiceImplTest {
     @BeforeEach
     void insert() {
         this.theaterDto = createTestTheater("테스트 공연장");
-        manageTheaterService.saveTheater(theaterDto);
+        Long userId = 1L;
+        manageTheaterService.saveTheater(theaterDto, userId);
     }
 
     @Test
@@ -38,9 +39,10 @@ class TheaterManageServiceImplTest {
     void givenTheaterInfo_whenAddTheaterInfo_thenSuccess() {
         //given
         TheaterDto theaterTestDto = createTestTheater("새로운공연장");
+        Long userId = 1L;
 
         //when & then
-        assertDoesNotThrow(() -> manageTheaterService.saveTheater(theaterTestDto));
+        assertDoesNotThrow(() -> manageTheaterService.saveTheater(theaterTestDto, userId));
     }
 
     @Test
@@ -48,9 +50,10 @@ class TheaterManageServiceImplTest {
     void givenExistTheaterName_whenAddTheaterInfo_thenThrowException() {
         //given
         TheaterDto theaterTestDto = theaterDto;
+        Long userId = 1L;
 
         //when
-        Exception exception = assertThrows(Exception.class, () -> manageTheaterService.saveTheater(theaterTestDto));
+        Exception exception = assertThrows(Exception.class, () -> manageTheaterService.saveTheater(theaterTestDto, userId));
 
         //then
         assertTrue(exception instanceof DataDuplicateKeyException);

--- a/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
@@ -5,6 +5,8 @@ import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.application.theater.dto.TheaterRoomDto;
 import com.melodymarket.application.theater.dto.TheaterSeatDto;
 import com.melodymarket.application.theater.service.ManageTheaterServiceImpl;
+import com.melodymarket.domain.user.entity.User;
+import com.melodymarket.infrastructure.security.MelodyUserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -27,7 +30,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("공연장 API 테스트")
-@WithMockUser(roles = "USER")
 @WebMvcTest(ManageTheaterController.class)
 class ManageTheaterControllerTest {
 
@@ -42,6 +44,12 @@ class ManageTheaterControllerTest {
 
     @BeforeEach
     void setUp() {
+        User testUser = User.builder().loginId("testUser").userPassword("testPassword").build();
+        MelodyUserDetails userDetails = new MelodyUserDetails(testUser);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
                 .apply(springSecurity())
@@ -50,7 +58,6 @@ class ManageTheaterControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = "USER")
     @DisplayName("[POST] 공연장 등록 API 테스트")
     void givenTestTheater_whenAddTheater_thenSuccess() throws Exception {
         //given


### PR DESCRIPTION
* 공연장 등록 시 유저 아이디 값이 같이 저장되지 않아 어떤 유저가 등록 및 수정 조회 가능한지 스코프를 알 수 없는 문제가 있어 유저 아이디도 같이 저장하도록 추가
* 스프링시큐리티 AuthenticationPrincipal를 통해 유저 아이디 값을 조회함으로 써 컨트롤러 테스트 시 유저 데이터를 받을 수 있도록 추가
* 저장 시 유저 아이디가 필요하므로 서비스 테스트에도 유저 아이디값 넣도록 수정
* findByTheaterName메서드는 굳이 필요없는 메서드 분리로 판단하여 바로 리포지토리를 통해 조회하도록 제거


close #47 