### PR TITLE
FEAT: 공연장을 생성한 유저가 등록한 공연장 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
@@ -3,7 +3,10 @@ package com.melodymarket.application.theater.service;
 import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 
+import java.util.List;
+
 public interface ManageTheaterService {
     TheaterResponseDto saveTheater(TheaterDto theaterDto, Long userId);
 
+    List<TheaterResponseDto> getTheaterList(Long userId);
 }

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface ManageTheaterService {
     TheaterResponseDto saveTheater(TheaterDto theaterDto, Long userId);
 
-    List<TheaterResponseDto> getTheaterList(Long userId);
+    List<TheaterResponseDto> getTheaterList(Long userId, int pageNo, String criteria);
 }

--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -4,6 +4,7 @@ import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.domain.theater.entity.Theater;
 import com.melodymarket.domain.theater.entity.TheaterRoom;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
+import com.melodymarket.infrastructure.exception.DataNotFoundException;
 import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 import lombok.AccessLevel;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
@@ -34,6 +37,14 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
     private void setTheaterPersistence(Theater theater) {
         theater.associateTheaterWithRooms();
         theater.getRooms().forEach(TheaterRoom::associateRoomsWithSeats);
+    }
 
+    @Override
+    public List<TheaterResponseDto> getTheaterList(Long userId) {
+        List<Theater> theaterList = theaterRepository.findTheatersByUserId(userId);
+        if (theaterList.isEmpty()) {
+            throw new DataNotFoundException("유저가 등록한 공연이 없습니다.");
+        }
+        return theaterList.stream().map(TheaterResponseDto::from).toList();
     }
 }

--- a/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.melodymarket.common.exception;
 
 import com.melodymarket.common.dto.ResponseDto;
+import com.melodymarket.infrastructure.exception.DataNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
@@ -56,5 +57,10 @@ public class GlobalExceptionHandler {
         log.error("[handleDataAccessException] 데이터 처리 중 오류가 발생했습니다={}", ex.getMessage());
 
         return ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), "데이터 처리 중 에러가 발생하였습니다.");
+    }
+
+    @ExceptionHandler(DataNotFoundException.class)
+    public ResponseDto<String> handleDataNotFoundException(DataNotFoundException ex) {
+        return ResponseDto.of(HttpStatus.NO_CONTENT, ex.getMessage(), null);
     }
 }

--- a/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
+++ b/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
@@ -3,9 +3,13 @@ package com.melodymarket.infrastructure.jpa.theater.repository;
 import com.melodymarket.domain.theater.entity.Theater;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TheaterRepository extends JpaRepository<Theater, Long> {
     @Override
     <S extends Theater> S save(S theaterEntity);
 
     boolean existsByName(String name);
+
+    List<Theater> findTheatersByUserId(Long userId);
 }

--- a/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
+++ b/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
@@ -1,9 +1,9 @@
 package com.melodymarket.infrastructure.jpa.theater.repository;
 
 import com.melodymarket.domain.theater.entity.Theater;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface TheaterRepository extends JpaRepository<Theater, Long> {
     @Override
@@ -11,5 +11,5 @@ public interface TheaterRepository extends JpaRepository<Theater, Long> {
 
     boolean existsByName(String name);
 
-    List<Theater> findTheatersByUserId(Long userId);
+    Page<Theater> findTheatersByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
+++ b/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
@@ -10,10 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -33,5 +32,13 @@ public class ManageTheaterController {
         return ResponseDto.of(HttpStatus.OK,
                 "공연장 등록이 완료되었습니다.",
                 manageTheaterService.saveTheater(theaterDto, melodyUserDetails.getId()));
+    }
+
+    @GetMapping("/list")
+    public ResponseDto<List<TheaterResponseDto>> getTheaterList(@AuthenticationPrincipal MelodyUserDetails userDetails) {
+        log.info("user Id ={}", userDetails.getId());
+        return ResponseDto.of(HttpStatus.OK,
+                "공연장 리스트 조회 성공",
+                manageTheaterService.getTheaterList(userDetails.getId()));
     }
 }

--- a/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
+++ b/src/main/java/com/melodymarket/presentation/theater/controller/ManageTheaterController.java
@@ -35,10 +35,12 @@ public class ManageTheaterController {
     }
 
     @GetMapping("/list")
-    public ResponseDto<List<TheaterResponseDto>> getTheaterList(@AuthenticationPrincipal MelodyUserDetails userDetails) {
+    public ResponseDto<List<TheaterResponseDto>> getTheaterList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
+                                                                @RequestParam(required = false, defaultValue = "name", value = "criteria") String criteria,
+                                                                @AuthenticationPrincipal MelodyUserDetails userDetails) {
         log.info("user Id ={}", userDetails.getId());
         return ResponseDto.of(HttpStatus.OK,
                 "공연장 리스트 조회 성공",
-                manageTheaterService.getTheaterList(userDetails.getId()));
+                manageTheaterService.getTheaterList(userDetails.getId(), pageNo, criteria));
     }
 }

--- a/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
+++ b/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
@@ -1,10 +1,14 @@
 package com.melodymarket.presentation.theater.dto;
 
 import com.melodymarket.application.theater.dto.TheaterDto;
+import com.melodymarket.domain.theater.entity.Theater;
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 public class TheaterResponseDto {
+    Long id;
     String name;
     String location;
 
@@ -12,6 +16,14 @@ public class TheaterResponseDto {
         return TheaterResponseDto.builder()
                 .name(theaterDto.getName())
                 .location(theaterDto.getLocation())
+                .build();
+    }
+
+    public static TheaterResponseDto from(Theater theater) {
+        return TheaterResponseDto.builder()
+                .id(theater.getId())
+                .name(theater.getName())
+                .location(theater.getLocation())
                 .build();
     }
 }

--- a/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
+++ b/src/main/java/com/melodymarket/presentation/theater/dto/TheaterResponseDto.java
@@ -2,10 +2,12 @@ package com.melodymarket.presentation.theater.dto;
 
 import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.domain.theater.entity.Theater;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
+@AllArgsConstructor
 @Getter
 public class TheaterResponseDto {
     Long id;

--- a/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
@@ -69,7 +69,7 @@ class TheaterManageServiceImplTest {
         Long userId = 1L;
 
         //when
-        List<TheaterResponseDto> theaterResponseDtoList = manageTheaterService.getTheaterList(userId);
+        List<TheaterResponseDto> theaterResponseDtoList = manageTheaterService.getTheaterList(userId,0,"name");
 
         //then
         Assertions.assertThat(theaterResponseDtoList).hasSize(1);
@@ -83,7 +83,7 @@ class TheaterManageServiceImplTest {
         Long userId = 2L;
 
         //when
-        Exception exception = assertThrows(Exception.class, () -> manageTheaterService.getTheaterList(userId));
+        Exception exception = assertThrows(Exception.class, () -> manageTheaterService.getTheaterList(userId, 0, "name"));
 
         //then
         assertTrue(exception instanceof DataNotFoundException);

--- a/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
@@ -4,21 +4,24 @@ import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.application.theater.dto.TheaterRoomDto;
 import com.melodymarket.application.theater.dto.TheaterSeatDto;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
+import com.melodymarket.infrastructure.exception.DataNotFoundException;
 import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
+import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
-@Transactional
+@DataJpaTest
+@Import(ManageTheaterServiceImpl.class)
 @DisplayName("공연장 관리 서비스 테스트")
 class TheaterManageServiceImplTest {
     @Autowired
@@ -57,6 +60,33 @@ class TheaterManageServiceImplTest {
 
         //then
         assertTrue(exception instanceof DataDuplicateKeyException);
+    }
+
+    @Test
+    @DisplayName("공연장을 등록한 유저의 공연장 리스트 조회 시 성공")
+    void givenRegisterTheaterByUser_whenGetTheaterList_thenGetTheaterListSuccessfully() {
+        //given
+        Long userId = 1L;
+
+        //when
+        List<TheaterResponseDto> theaterResponseDtoList = manageTheaterService.getTheaterList(userId);
+
+        //then
+        Assertions.assertThat(theaterResponseDtoList).hasSize(1);
+        Assertions.assertThat(theaterResponseDtoList.get(0).getName()).isEqualTo("테스트 공연장");
+    }
+
+    @Test
+    @DisplayName("공연장을 등록하지 않은 유저의 공연장 리스트 조회 시 예외 발생 테스트")
+    void givenNotRegisterTheaterByUser_whenGetTheaterList_thenThrowException() {
+        //given
+        Long userId = 2L;
+
+        //when
+        Exception exception = assertThrows(Exception.class, () -> manageTheaterService.getTheaterList(userId));
+
+        //then
+        assertTrue(exception instanceof DataNotFoundException);
     }
 
     private TheaterDto createTestTheater(String name) {

--- a/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -70,6 +71,19 @@ class ManageTheaterControllerTest {
         ResultActions resultActions = mockMvc.perform(post("/v1/theater/add")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json));
+        //then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[GET] 공연장 리스트 조회 API 테스트")
+    void givenTestUser_whenGetTheaterList_thenSuccess() throws Exception {
+        //given
+        //BeforeEach Setting User
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/v1/theater/list"));
+
         //then
         resultActions.andExpect(status().isOk());
     }

--- a/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
@@ -93,8 +93,6 @@ class ManageTheaterControllerTest {
     void givenTestUser_whenGetTheaterList_thenSuccess() throws Exception {
         //given
         Long userId = this.userId;
-
-        //when
         Theater theater = Mockito.mock(Theater.class);
         when(theater.getId()).thenReturn(userId);
         when(theater.getName()).thenReturn("공연장");
@@ -102,6 +100,8 @@ class ManageTheaterControllerTest {
         TheaterResponseDto theaterResponseDto = new TheaterResponseDto(userId, "공연장", "위치");
         when(manageTheaterService.getTheaterList(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyString()))
                 .thenReturn(List.of(theaterResponseDto));
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/v1/theater/list"));
 
         //then

--- a/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
+++ b/src/test/java/com/melodymarket/presentation/theater/controller/ManageTheaterControllerTest.java
@@ -5,11 +5,15 @@ import com.melodymarket.application.theater.dto.TheaterDto;
 import com.melodymarket.application.theater.dto.TheaterRoomDto;
 import com.melodymarket.application.theater.dto.TheaterSeatDto;
 import com.melodymarket.application.theater.service.ManageTheaterServiceImpl;
+import com.melodymarket.domain.theater.entity.Theater;
 import com.melodymarket.domain.user.entity.User;
+import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
 import com.melodymarket.infrastructure.security.MelodyUserDetails;
+import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,10 +28,12 @@ import org.springframework.web.context.WebApplicationContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("공연장 API 테스트")
@@ -36,6 +42,8 @@ class ManageTheaterControllerTest {
 
     @MockBean
     ManageTheaterServiceImpl manageTheaterService;
+    @MockBean
+    TheaterRepository theaterRepository;
     @Autowired
     MockMvc mockMvc;
     @Autowired
@@ -43,13 +51,18 @@ class ManageTheaterControllerTest {
     @Autowired
     WebApplicationContext webApplicationContext;
 
+    Long userId;
+
+
     @BeforeEach
     void setUp() {
-        User testUser = User.builder().loginId("testUser").userPassword("testPassword").build();
+        User testUser = Mockito.spy(User.builder().loginId("testUser").build());
+        when(testUser.getId()).thenReturn(1L);
         MelodyUserDetails userDetails = new MelodyUserDetails(testUser);
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
+        this.userId = userDetails.getId();
 
         this.mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
@@ -79,13 +92,25 @@ class ManageTheaterControllerTest {
     @DisplayName("[GET] 공연장 리스트 조회 API 테스트")
     void givenTestUser_whenGetTheaterList_thenSuccess() throws Exception {
         //given
-        //BeforeEach Setting User
+        Long userId = this.userId;
 
         //when
+        Theater theater = Mockito.mock(Theater.class);
+        when(theater.getId()).thenReturn(userId);
+        when(theater.getName()).thenReturn("공연장");
+        when(theater.getLocation()).thenReturn("위치");
+        TheaterResponseDto theaterResponseDto = new TheaterResponseDto(userId, "공연장", "위치");
+        when(manageTheaterService.getTheaterList(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyString()))
+                .thenReturn(List.of(theaterResponseDto));
         ResultActions resultActions = mockMvc.perform(get("/v1/theater/list"));
 
         //then
-        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("OK"))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].name").value("공연장"))
+                .andExpect(jsonPath("$.data[0].location").value("위치"))
+                .andExpect(jsonPath("$.data[0].id").value(1L));
     }
 
     private TheaterDto createTestTheater() {


### PR DESCRIPTION
공연장을 등록한 사용자가 자신이 등록한 공연장에 대한 리스트를 조회할 수 있도록 API 구현 완료하였습니다.

페이징을 사용하여 페이지 별로 데이터를 요청할 수 있도록 하였으며, 등록한 공연장 리스트 조회 시 상세 정보에 대한 요청은
API를 분리하여 Theater 테이블의 키값으로 조회할 수 있도록 개발 예정에 있습니다.

close #29 