### PR TITLE
FEAT: [#52] 공연장 정보 조회 시 조회 권한 검증 로직 추가

### DIFF
--- a/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/ManageTheaterServiceImpl.java
@@ -37,6 +37,8 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
     TheaterRoomRepository theaterRoomRepository;
     ResponseMapper responseMapper;
     TheaterSeatRepository theaterSeatRepository;
+    TheaterAuthorizationService theaterAuthorizationService;
+
 
     @Transactional
     @Override
@@ -68,6 +70,8 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
 
     @Override
     public List<TheaterRoomResponseDto> getTheaterRoomList(Long userId, Long theaterId, int pageNo, String criteria) {
+        theaterAuthorizationService.authenticationUserId(userId, theaterId);
+
         Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE, Sort.by(Sort.Direction.DESC, criteria));
         Page<TheaterRoom> theaterRoomsPage = theaterRoomRepository.findTheaterRoomsByTheaterId(theaterId, pageable);
         if (theaterRoomsPage.isEmpty()) {
@@ -79,6 +83,8 @@ public class ManageTheaterServiceImpl implements ManageTheaterService {
 
     @Override
     public List<TheaterSeatResponseDto> getTheaterSeatList(Long userId, Long theaterId, Long roomId, int floor, int pageNo, String criteria) {
+        theaterAuthorizationService.authenticationUserId(userId, theaterId);
+
         Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE, Sort.by(Sort.Direction.ASC, criteria));
         Page<TheaterSeat> theaterSeatPage = theaterSeatRepository.findByTheaterRoomIdAndSeatFloorOrderBySeatRowAscSeatNumberAsc(roomId, floor, pageable);
         if (theaterSeatPage.isEmpty()) {

--- a/src/main/java/com/melodymarket/application/theater/service/TheaterAuthorizationService.java
+++ b/src/main/java/com/melodymarket/application/theater/service/TheaterAuthorizationService.java
@@ -1,0 +1,6 @@
+package com.melodymarket.application.theater.service;
+
+public interface TheaterAuthorizationService {
+    void authenticationUserId(Long userId, Long theaterId);
+
+}

--- a/src/main/java/com/melodymarket/application/theater/service/TheaterAuthorizationServiceImpl.java
+++ b/src/main/java/com/melodymarket/application/theater/service/TheaterAuthorizationServiceImpl.java
@@ -1,0 +1,24 @@
+package com.melodymarket.application.theater.service;
+
+import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Service
+public class TheaterAuthorizationServiceImpl implements TheaterAuthorizationService {
+    TheaterRepository theaterRepository;
+
+    @Override
+    public void authenticationUserId(Long userId, Long theaterId) {
+        Optional<Long> foundUserId = theaterRepository.findUserIdById(theaterId);
+        if (foundUserId.isEmpty() || !foundUserId.get().equals(userId)) {
+            throw new IllegalStateException("유저(" + userId + ") 는 (" + theaterId + ") 에 대한 작업 권한이 불충분 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/melodymarket/common/exception/GlobalExceptionHandler.java
@@ -63,4 +63,9 @@ public class GlobalExceptionHandler {
     public ResponseDto<String> handleDataNotFoundException(DataNotFoundException ex) {
         return ResponseDto.of(HttpStatus.NO_CONTENT, ex.getMessage(), null);
     }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseDto<String> handleIllegalStateException(IllegalStateException ex) {
+        return ResponseDto.of(HttpStatus.FORBIDDEN, ex.getMessage(), null);
+    }
 }

--- a/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
+++ b/src/main/java/com/melodymarket/infrastructure/jpa/theater/repository/TheaterRepository.java
@@ -4,6 +4,9 @@ import com.melodymarket.domain.theater.entity.Theater;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface TheaterRepository extends JpaRepository<Theater, Long> {
     @Override
@@ -12,4 +15,7 @@ public interface TheaterRepository extends JpaRepository<Theater, Long> {
     boolean existsByName(String name);
 
     Page<Theater> findTheatersByUserId(Long userId, Pageable pageable);
+
+    @Query("SELECT t.userId FROM Theater t WHERE t.id = :id")
+    Optional<Long> findUserIdById(Long id);
 }

--- a/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
+++ b/src/test/java/com/melodymarket/application/theater/service/TheaterManageServiceImplTest.java
@@ -7,7 +7,6 @@ import com.melodymarket.common.mapper.ResponseMapper;
 import com.melodymarket.common.mapper.ResponseMapperImpl;
 import com.melodymarket.infrastructure.exception.DataDuplicateKeyException;
 import com.melodymarket.infrastructure.exception.DataNotFoundException;
-import com.melodymarket.infrastructure.jpa.theater.repository.TheaterRepository;
 import com.melodymarket.presentation.theater.dto.TheaterResponseDto;
 import com.melodymarket.presentation.theater.dto.TheaterRoomResponseDto;
 import com.melodymarket.presentation.theater.dto.TheaterSeatResponseDto;
@@ -26,15 +25,15 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-@Import({ManageTheaterServiceImpl.class, ResponseMapperImpl.class})
+@Import({ManageTheaterServiceImpl.class, ResponseMapperImpl.class, TheaterAuthorizationServiceImpl.class})
 @DisplayName("공연장 관리 서비스 테스트")
 class TheaterManageServiceImplTest {
     @Autowired
     ManageTheaterService manageTheaterService;
     @Autowired
-    TheaterRepository theaterRepository;
-    @Autowired
     ResponseMapper responseMapper;
+    @Autowired
+    TheaterAuthorizationService theaterAuthorizationService;
     TheaterDto theaterDto;
     final int insertTheaterRoom = 3;
     final int insertSeat = 5;
@@ -128,7 +127,7 @@ class TheaterManageServiceImplTest {
         Exception exception = assertThrows(Exception.class, () -> manageTheaterService.getTheaterRoomList(userId, theaterId, 0, "name"));
 
         //then
-        assertTrue(exception instanceof DataNotFoundException);
+        assertTrue(exception instanceof IllegalStateException);
     }
 
     @Test


### PR DESCRIPTION
* theater 정보에 대해 user 요청 시 유저의 권한이 올바른지 체크하는 theaterAuthorizationService 메서드 추가
* 요청이 올바르지 않은 경우 권한이 불충분하다는 excetion 반환
* 요청 불충분 excetion에 처리를 위한 GlobalExceptionHandler 추가
* 권한 검사 시 Entity 전체를 로드하지 않도록 userid 만 조회하도록 jpql 사용